### PR TITLE
Container rename

### DIFF
--- a/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
@@ -80,7 +80,7 @@ namespace ModestTree.Zenject
 
                 if (installer.enabled)
                 {
-                    installer.DiContainer = container;
+                    installer.Container = container;
                     container.Bind<IInstaller>().To(installer);
                 }
 

--- a/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
@@ -66,9 +66,7 @@ namespace ModestTree.Zenject
 
         static IEnumerable<ZenjectResolveException> ValidateInstallers(CompositionRoot compRoot)
         {
-            var container = new DiContainer();
-
-            container.AllowNullBindings = true;
+            var container = new DiContainer {AllowNullBindings = true};
             container.Bind<CompositionRoot>().ToSingle(compRoot);
 
             foreach (var installer in compRoot.Installers)
@@ -82,7 +80,7 @@ namespace ModestTree.Zenject
 
                 if (installer.enabled)
                 {
-                    installer.Container = container;
+                    installer.DiContainer = container;
                     container.Bind<IInstaller>().To(installer);
                 }
 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
@@ -1,17 +1,13 @@
-using System;
 using System.Collections.Generic;
-using UnityEngine;
-using System.Linq;
 
 namespace ModestTree.Zenject
 {
-    // We extract the interface so that monobehaviours can be installers
+    /// <summary>
+    ///     We extract the interface so that monobehaviours can be installers
+    /// </summary>
     public interface IInstaller
     {
-        DiContainer DiContainer
-        {
-            set;
-        }
+        DiContainer Container { set; }
 
         void InstallBindings();
 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
@@ -8,7 +8,7 @@ namespace ModestTree.Zenject
     // We extract the interface so that monobehaviours can be installers
     public interface IInstaller
     {
-        DiContainer Container
+        DiContainer DiContainer
         {
             set;
         }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
@@ -1,20 +1,19 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
 
 namespace ModestTree.Zenject
 {
     public abstract class Installer : IInstaller
     {
-        protected DiContainer _container;
+        protected DiContainer Container;
 
         [Inject]
-        public DiContainer Container
+        public DiContainer DiContainer
         {
             set
             {
-                _container = value;
+                Container = value;
             }
         }
 
@@ -29,7 +28,7 @@ namespace ModestTree.Zenject
         // Helper method for ValidateSubGraphs
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return _container.ValidateObjectGraph<T>(extraTypes);
+            return Container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
@@ -6,15 +6,13 @@ namespace ModestTree.Zenject
 {
     public abstract class Installer : IInstaller
     {
-        protected DiContainer Container;
+        private DiContainer _container;
 
         [Inject]
-        public DiContainer DiContainer
+        public DiContainer Container
         {
-            set
-            {
-                Container = value;
-            }
+            set { _container = value; }
+            protected get { return _container; }
         }
 
         public abstract void InstallBindings();
@@ -25,10 +23,12 @@ namespace ModestTree.Zenject
             return Enumerable.Empty<ZenjectResolveException>();
         }
 
-        // Helper method for ValidateSubGraphs
+        /// <summary>
+        ///     Helper method for ValidateSubGraphs
+        /// </summary>
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return Container.ValidateObjectGraph<T>(extraTypes);
+            return _container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
@@ -1,26 +1,19 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
+using UnityEngine;
 
 namespace ModestTree.Zenject
 {
     public abstract class MonoInstaller : MonoBehaviour, IInstaller
     {
-        protected DiContainer Container;
+        private DiContainer _container;
 
         [Inject]
-        public DiContainer DiContainer
+        public DiContainer Container
         {
-            set
-            {
-                Container = value;
-            }
-        }
-
-        public virtual void Start()
-        {
-            // Define this method so we expose the enabled check box
+            set { _container = value; }
+            protected get { return _container; }
         }
 
         public abstract void InstallBindings();
@@ -31,10 +24,17 @@ namespace ModestTree.Zenject
             return Enumerable.Empty<ZenjectResolveException>();
         }
 
-        // Helper method for ValidateSubGraphs
+        public virtual void Start()
+        {
+            // Define this method so we expose the enabled check box
+        }
+
+        /// <summary>
+        ///     Helper method for ValidateSubGraphs
+        /// </summary>
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return Container.ValidateObjectGraph<T>(extraTypes);
+            return _container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
@@ -7,14 +7,14 @@ namespace ModestTree.Zenject
 {
     public abstract class MonoInstaller : MonoBehaviour, IInstaller
     {
-        protected DiContainer _container;
+        protected DiContainer Container;
 
         [Inject]
-        public DiContainer Container
+        public DiContainer DiContainer
         {
             set
             {
-                _container = value;
+                Container = value;
             }
         }
 
@@ -34,7 +34,7 @@ namespace ModestTree.Zenject
         // Helper method for ValidateSubGraphs
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return _container.ValidateObjectGraph<T>(extraTypes);
+            return Container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablePrioritiesInstaller.cs
@@ -6,7 +6,7 @@ namespace ModestTree.Zenject
 {
     public class DisposablePrioritiesInstaller : Installer
     {
-        List<Type> _disposables;
+        readonly List<Type> _disposables;
 
         public DisposablePrioritiesInstaller(List<Type> disposables)
         {
@@ -19,7 +19,7 @@ namespace ModestTree.Zenject
 
             foreach (var disposableType in _disposables)
             {
-                BindPriority(_container, disposableType, priorityCount);
+                BindPriority(Container, disposableType, priorityCount);
                 priorityCount++;
             }
         }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializablePrioritiesInstaller.cs
@@ -6,7 +6,7 @@ namespace ModestTree.Zenject
 {
     public class InitializablePrioritiesInstaller : Installer
     {
-        List<Type> _initializables;
+        readonly List<Type> _initializables;
 
         public InitializablePrioritiesInstaller(
             List<Type> initializables)
@@ -20,7 +20,7 @@ namespace ModestTree.Zenject
 
             foreach (var initializableType in _initializables)
             {
-                BindPriority(_container, initializableType, priorityCount);
+                BindPriority(Container, initializableType, priorityCount);
                 priorityCount++;
             }
         }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardUnityInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardUnityInstaller.cs
@@ -8,18 +8,18 @@ namespace ModestTree.Zenject
         // Install basic functionality for most unity apps
         public override void InstallBindings()
         {
-            _container.Bind<UnityKernel>().ToSingleGameObject();
+            Container.Bind<UnityKernel>().ToSingleGameObject();
 
-            _container.Bind<UnityEventManager>().ToSingleGameObject();
-            _container.Bind<GameObjectInstantiator>().ToSingle();
+            Container.Bind<UnityEventManager>().ToSingleGameObject();
+            Container.Bind<GameObjectInstantiator>().ToSingle();
 
-            _container.Bind<StandardKernel>().ToSingle();
+            Container.Bind<StandardKernel>().ToSingle();
             // TODO: Do this instead:
             //_container.Bind<IKernel>().ToTransient<StandardKernel>();
 
-            _container.Bind<InitializableHandler>().ToSingle();
-            _container.Bind<DisposablesHandler>().ToSingle();
-            _container.Bind<ITickable>().ToLookup<UnityEventManager>();
+            Container.Bind<InitializableHandler>().ToSingle();
+            Container.Bind<DisposablesHandler>().ToSingle();
+            Container.Bind<ITickable>().ToLookup<UnityEventManager>();
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/TickablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/TickablePrioritiesInstaller.cs
@@ -6,7 +6,7 @@ namespace ModestTree.Zenject
 {
     public class TickablePrioritiesInstaller : Installer
     {
-        List<Type> _tickables;
+        readonly List<Type> _tickables;
 
         public TickablePrioritiesInstaller(
             List<Type> tickables)
@@ -20,7 +20,7 @@ namespace ModestTree.Zenject
 
             foreach (var tickableType in _tickables)
             {
-                BindPriority(_container, tickableType, priorityCount);
+                BindPriority(Container, tickableType, priorityCount);
                 priorityCount++;
             }
         }


### PR DESCRIPTION
In order to remove collision of names ("_container" is protected), injected "Container" is renamed to "DiContainer" and "_container" to "Container".
