### PR TITLE
Assembly with base types

### DIFF
--- a/AssemblyBuild/Zenject.sln
+++ b/AssemblyBuild/Zenject.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zenject", "..\UnityProject\Assets\Zenject\Main\Scripts\Zenject.csproj", "{46F25A62-2E29-48CB-95F3-BDBCB0976DDC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zenject-editor", "..\UnityProject\Assets\Zenject\Main\Editor\Zenject-editor.csproj", "{B71F2201-3382-46B3-A9C6-219A72954905}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zenject.Api", "..\UnityProject\Assets\Zenject\Main\Scripts\Zenject.Api.csproj", "{73A60B22-4135-4B72-9306-93263AAA9C2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{B71F2201-3382-46B3-A9C6-219A72954905}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B71F2201-3382-46B3-A9C6-219A72954905}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B71F2201-3382-46B3-A9C6-219A72954905}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73A60B22-4135-4B72-9306-93263AAA9C2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73A60B22-4135-4B72-9306-93263AAA9C2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73A60B22-4135-4B72-9306-93263AAA9C2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73A60B22-4135-4B72-9306-93263AAA9C2B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Asteroid/Asteroid.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Asteroid/Asteroid.cs
@@ -1,5 +1,6 @@
 using System;
 using ModestTree;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 using System.Collections;
 using ModestTree.Zenject;

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Asteroid/AsteroidManager.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Asteroid/AsteroidManager.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using ModestTree;
+using ModestTree.Zenject.Api.Factories;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
-using System.Collections;
-using ModestTree.Zenject;
 using Random=UnityEngine.Random;
 using System.Linq;
 

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Installers/AsteroidsInstaller.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Installers/AsteroidsInstaller.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 using System.Collections;
 using ModestTree.Zenject;
@@ -36,22 +38,22 @@ namespace ModestTree.Asteroids
         void InstallIncludes()
         {
             // This installer is needed for all unity projects (Yes, Zenject can support non-unity projects)
-            _container.Bind<IInstaller>().ToSingle<StandardUnityInstaller>();
+            Container.Bind<IInstaller>().ToSingle<StandardUnityInstaller>();
         }
 
         void InstallAsteroids()
         {
             // Root of our object graph
-            _container.Bind<IDependencyRoot>().ToSingle<DependencyRootStandard>();
+            Container.Bind<IDependencyRoot>().ToSingle<DependencyRootStandard>();
 
             // In this game there is only one camera so an enum isn't necessary
             // but used here to show how it would work if there were multiple
-            _container.Bind<Camera>().ToSingle(SceneSettings.MainCamera).As(Cameras.Main);
+            Container.Bind<Camera>().ToSingle(SceneSettings.MainCamera).As(Cameras.Main);
 
-            _container.Bind<LevelHelper>().ToSingle();
+            Container.Bind<LevelHelper>().ToSingle();
 
-            _container.Bind<ITickable>().ToSingle<AsteroidManager>();
-            _container.Bind<AsteroidManager>().ToSingle();
+            Container.Bind<ITickable>().ToSingle<AsteroidManager>();
+            Container.Bind<AsteroidManager>().ToSingle();
 
             // Here, we're defining a generic factory to create asteroid objects using the given prefab
             // There's several different ways of instantiating new game objects in zenject, this is
@@ -60,44 +62,44 @@ namespace ModestTree.Asteroids
             // This line is exactly the same as the following:
             //_container.Bind<IFactory<IAsteroid>>().To(
                 //new GameObjectFactory<IAsteroid, Asteroid>(_container, SceneSettings.Asteroid.Prefab));
-            _container.BindFactory<IAsteroid, Asteroid>(SceneSettings.Asteroid.Prefab);
+            Container.BindFactory<IAsteroid, Asteroid>(SceneSettings.Asteroid.Prefab);
 
-            _container.Bind<IInitializable>().ToSingle<GameController>();
-            _container.Bind<ITickable>().ToSingle<GameController>();
-            _container.Bind<GameController>().ToSingle();
+            Container.Bind<IInitializable>().ToSingle<GameController>();
+            Container.Bind<ITickable>().ToSingle<GameController>();
+            Container.Bind<GameController>().ToSingle();
 
-            _container.Bind<ShipStateFactory>().ToSingle();
+            Container.Bind<ShipStateFactory>().ToSingle();
 
             // Here's another way to create game objects dynamically, by using ToTransientFromPrefab
             // We prefer to use ITickable / IInitializable in favour of the Monobehaviour methods
             // so we just use a monobehaviour wrapper class here to pass in asset data
-            _container.Bind<ShipHooks>().ToTransientFromPrefab<ShipHooks>(SceneSettings.Ship.Prefab).WhenInjectedInto<Ship>();
+            Container.Bind<ShipHooks>().ToTransientFromPrefab<ShipHooks>(SceneSettings.Ship.Prefab).WhenInjectedInto<Ship>();
 
-            _container.Bind<Ship>().ToSingle();
-            _container.Bind<ITickable>().ToSingle<Ship>();
-            _container.Bind<IInitializable>().ToSingle<Ship>();
+            Container.Bind<Ship>().ToSingle();
+            Container.Bind<ITickable>().ToSingle<Ship>();
+            Container.Bind<IInitializable>().ToSingle<Ship>();
         }
 
         void InstallSettings()
         {
-            _container.Bind<ShipStateMoving.Settings>().ToSingle(SceneSettings.Ship.StateMoving);
-            _container.Bind<ShipStateDead.Settings>().ToSingle(SceneSettings.Ship.StateDead);
-            _container.Bind<ShipStateWaitingToStart.Settings>().ToSingle(SceneSettings.Ship.StateStarting);
+            Container.Bind<ShipStateMoving.Settings>().ToSingle(SceneSettings.Ship.StateMoving);
+            Container.Bind<ShipStateDead.Settings>().ToSingle(SceneSettings.Ship.StateDead);
+            Container.Bind<ShipStateWaitingToStart.Settings>().ToSingle(SceneSettings.Ship.StateStarting);
 
-            _container.Bind<AsteroidManager.Settings>().ToSingle(SceneSettings.Asteroid.Spawner);
-            _container.Bind<Asteroid.Settings>().ToSingle(SceneSettings.Asteroid.General);
+            Container.Bind<AsteroidManager.Settings>().ToSingle(SceneSettings.Asteroid.Spawner);
+            Container.Bind<Asteroid.Settings>().ToSingle(SceneSettings.Asteroid.General);
         }
 
         // We don't need to include these bindings but often its nice to have
         // control over initialization-order and update-order
         void InitPriorities()
         {
-            _container.Bind<IInstaller>().ToSingle<InitializablePrioritiesInstaller>();
-            _container.Bind<List<Type>>().To(Initializables)
+            Container.Bind<IInstaller>().ToSingle<InitializablePrioritiesInstaller>();
+            Container.Bind<List<Type>>().To(Initializables)
                 .WhenInjectedInto<InitializablePrioritiesInstaller>();
 
-            _container.Bind<IInstaller>().ToSingle<TickablePrioritiesInstaller>();
-            _container.Bind<List<Type>>().To(Tickables)
+            Container.Bind<IInstaller>().ToSingle<TickablePrioritiesInstaller>();
+            Container.Bind<List<Type>>().To(Tickables)
                 .WhenInjectedInto<TickablePrioritiesInstaller>();
         }
 

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Main/GameController.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Main/GameController.cs
@@ -1,6 +1,5 @@
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
-using System.Collections;
-using ModestTree.Zenject;
 
 namespace ModestTree.Asteroids
 {

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Misc/GuiHandler.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Misc/GuiHandler.cs
@@ -1,6 +1,5 @@
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
-using System.Collections;
-using ModestTree.Zenject;
 
 namespace ModestTree.Asteroids
 {

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Misc/LevelHelper.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Misc/LevelHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 using System.Collections;
 using ModestTree.Zenject;

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Ship/Ship.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Ship/Ship.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
-using System.Collections;
-using ModestTree.Zenject;
 
 namespace ModestTree.Asteroids
 {

--- a/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Ship/ShipStateMoving.cs
+++ b/UnityProject/Assets/Zenject/Extras/SampleGame/Scripts/Ship/ShipStateMoving.cs
@@ -1,4 +1,5 @@
 using System;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 using System.Collections;
 using ModestTree.Zenject;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestAllInjectionTypes.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestAllInjectionTypes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestBaseClassPropertyInjection.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestBaseClassPropertyInjection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestBindScope.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestBindScope.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Collections.Generic;
-using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestCircularDependencies.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestCircularDependencies.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsFieldName.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsFieldName.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsIdentifier.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsIdentifier.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsParents.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsParents.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
 using NUnit.Framework;
 using System.Linq;
 using TestAssert=NUnit.Framework.Assert;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsTarget.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsTarget.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsTargetInstance.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestConditionsTargetInstance.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert = NUnit.Framework.Assert;
 

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestDuplicateInjection.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestDuplicateInjection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestFactoryTyped.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestFactoryTyped.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestKernel.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestKernel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using UnityEngine;
 using TestAssert = NUnit.Framework.Assert;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestListInjection.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestListInjection.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestMultiBind.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestMultiBind.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestMultipleInstallers.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestMultipleInstallers.cs
@@ -23,7 +23,7 @@ namespace ModestTree.Tests
             public static int Count;
             public override void InstallBindings()
             {
-                _container.Bind<IInstaller>().ToSingle<Test0>();
+                Container.Bind<IInstaller>().ToSingle<Test0>();
                 Count++;
             }
         }
@@ -33,7 +33,7 @@ namespace ModestTree.Tests
             public static int Count;
             public override void InstallBindings()
             {
-                _container.Bind<IInstaller>().ToSingle<Test0>();
+                Container.Bind<IInstaller>().ToSingle<Test0>();
                 Count++;
             }
         }

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestMultipleInstallers.cs.meta
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestMultipleInstallers.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6753996b1cf4864887fa9c2eabf5cc9
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestNestedContainer.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestNestedContainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestParameters.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestParameters.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestPostInjectCall.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestPostInjectCall.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestPropertyInjection.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestPropertyInjection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestSingleton.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestSingleton.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestTestOptional.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestTestOptional.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestValidateInstaller.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/TestValidateInstaller.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using UnityEngine;
 using TestAssert = NUnit.Framework.Assert;

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/ZenjectProfileTest.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Scripts/ZenjectProfileTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 using NUnit.Framework;
 using TestAssert=NUnit.Framework.Assert;
 

--- a/UnityProject/Assets/Zenject/Main/Editor/ZenEditorUtil.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenEditorUtil.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 using UnityEditor;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
@@ -80,7 +80,7 @@ namespace ModestTree.Zenject
 
                 if (installer.enabled)
                 {
-                    installer.DiContainer = container;
+                    installer.Container = container;
                     container.Bind<IInstaller>().To(installer);
                 }
 

--- a/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 using UnityEditor;
 using UnityEngine;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
@@ -66,9 +66,7 @@ namespace ModestTree.Zenject
 
         static IEnumerable<ZenjectResolveException> ValidateInstallers(CompositionRoot compRoot)
         {
-            var container = new DiContainer();
-
-            container.AllowNullBindings = true;
+            var container = new DiContainer {AllowNullBindings = true};
             container.Bind<CompositionRoot>().ToSingle(compRoot);
 
             foreach (var installer in compRoot.Installers)
@@ -82,7 +80,7 @@ namespace ModestTree.Zenject
 
                 if (installer.enabled)
                 {
-                    installer.Container = container;
+                    installer.DiContainer = container;
                     container.Bind<IInstaller>().To(installer);
                 }
 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Binders/BinderUntyped.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Binders/BinderUntyped.cs
@@ -1,4 +1,6 @@
 using System;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Binders/ReferenceBinder.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Binders/ReferenceBinder.cs
@@ -1,4 +1,6 @@
 using System;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Exceptions/ZenjectException.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Exceptions/ZenjectException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ModestTree.Zenject
+namespace ModestTree.Zenject.Api.Exceptions
 {
     public class ZenjectException : Exception
     {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/Factory.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/Factory.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Security.Permissions;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/Factory.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/Factory.cs
@@ -5,6 +5,7 @@ using System.Security.Permissions;
 using ModestTree.Zenject.Api;
 using ModestTree.Zenject.Api.Exceptions;
 using ModestTree.Zenject.Api.Factories;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryCustom.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryCustom.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryCustom.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryCustom.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using ModestTree.Zenject.Api;
 using ModestTree.Zenject.Api.Exceptions;
 using ModestTree.Zenject.Api.Factories;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryMethod.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryMethod.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryTyped.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryTyped.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using ModestTree.Zenject.Api;
 using ModestTree.Zenject.Api.Exceptions;
 using ModestTree.Zenject.Api.Factories;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryTyped.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/FactoryTyped.cs
@@ -1,19 +1,11 @@
 using System;
 using System.Collections.Generic;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 
 namespace ModestTree.Zenject
 {
-    public interface IValidatable
-    {
-        IEnumerable<ZenjectResolveException> Validate();
-    }
-
-    // Zero parameters
-    public interface IFactoryTyped<TValue> : IValidatable
-    {
-        TValue Create();
-    }
-
     public class FactoryTyped<TValue> : IFactoryTyped<TValue>
     {
         [Inject]
@@ -28,12 +20,6 @@ namespace ModestTree.Zenject
         {
             return _container.ValidateObjectGraph<TValue>();
         }
-    }
-
-    // One parameter
-    public interface IFactoryTyped<TParam1, TValue> : IValidatable
-    {
-        TValue Create(TParam1 param);
     }
 
     public class FactoryTyped<TParam1, TValue>
@@ -53,12 +39,6 @@ namespace ModestTree.Zenject
         }
     }
 
-    // Two parameters
-    public interface IFactoryTyped<TParam1, TParam2, TValue> : IValidatable
-    {
-        TValue Create(TParam1 param1, TParam2 param2);
-    }
-
     public class FactoryTyped<TParam1, TParam2, TValue> : IFactoryTyped<TParam1, TParam2, TValue>
     {
         [Inject]
@@ -74,12 +54,6 @@ namespace ModestTree.Zenject
             return _container.ValidateObjectGraph<TValue>(
                 typeof(TParam1), typeof(TParam2));
         }
-    }
-
-    // Three parameters
-    public interface IFactoryTyped<TParam1, TParam2, TParam3, TValue> : IValidatable
-    {
-        TValue Create(TParam1 param1, TParam2 param2, TParam3 param3);
     }
 
     public class FactoryTyped<TParam1, TParam2, TParam3, TValue>
@@ -98,12 +72,6 @@ namespace ModestTree.Zenject
             return _container.ValidateObjectGraph<TValue>(
                 typeof(TParam1), typeof(TParam2), typeof(TParam3));
         }
-    }
-
-    // Four parameters
-    public interface IFactoryTyped<TParam1, TParam2, TParam3, TParam4, TValue> : IValidatable
-    {
-        TValue Create(TParam1 param1, TParam2 param2, TParam3 param3, TParam4 param4);
     }
 
     public class FactoryTyped<TParam1, TParam2, TParam3, TParam4, TValue>

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/GameObjectFactory.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/GameObjectFactory.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/GameObjectInstantiator.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/GameObjectInstantiator.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/IFactory.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/IFactory.cs
@@ -1,18 +1,21 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
+using ModestTree.Zenject.Api.Exceptions;
 
-namespace ModestTree.Zenject
+namespace ModestTree.Zenject.Api.Factories
 {
-    // The difference between a factory and a provider:
-    // Factories create new instances, providers might return an existing instance
-    public interface IFactory<T>
+    /// <summary>
+    ///     The difference between a factory and a provider:
+    ///     Factories create new instances, providers might return an existing instance
+    /// </summary>
+    public interface IFactory<out T>
     {
-        // Note that we lose some type safety here when passing the arguments
-        // We are trading compile time checks for some flexibility
+        /// <summary>
+        ///     Note that we lose some type safety here when passing the arguments.
+        ///     We are trading compile time checks for some flexibility
+        /// </summary>
         T Create(params object[] constructorArgs);
 
         IEnumerable<ZenjectResolveException> Validate(params Type[] extraType);
     }
 }
-

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/IFactoryTyped.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/IFactoryTyped.cs
@@ -1,0 +1,42 @@
+namespace ModestTree.Zenject.Api.Factories
+{
+    /// <summary>
+    ///     Four parameters
+    /// </summary>
+    public interface IFactoryTyped<in TParam1, in TParam2, in TParam3, in TParam4, out TValue> : IValidatable
+    {
+        TValue Create(TParam1 param1, TParam2 param2, TParam3 param3, TParam4 param4);
+    }
+
+    /// <summary>
+    ///     Three parameters
+    /// </summary>
+    public interface IFactoryTyped<in TParam1, in TParam2, in TParam3, out TValue> : IValidatable
+    {
+        TValue Create(TParam1 param1, TParam2 param2, TParam3 param3);
+    }
+
+    /// <summary>
+    ///     Two parameters
+    /// </summary>
+    public interface IFactoryTyped<in TParam1, in TParam2, out TValue> : IValidatable
+    {
+        TValue Create(TParam1 param1, TParam2 param2);
+    }
+
+    /// <summary>
+    ///     One parameter
+    /// </summary>
+    public interface IFactoryTyped<in TParam1, out TValue> : IValidatable
+    {
+        TValue Create(TParam1 param);
+    }
+
+    /// <summary>
+    ///     Zero parameters
+    /// </summary>
+    public interface IFactoryTyped<out TValue> : IValidatable
+    {
+        TValue Create();
+    }
+}

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/IFactoryTyped.cs.meta
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/IFactoryTyped.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 141b064c6fa614a4e92aee34403f65f1
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/IValidatable.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/IValidatable.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using ModestTree.Zenject.Api.Exceptions;
+
+namespace ModestTree.Zenject.Api.Factories
+{
+    public interface IValidatable
+    {
+        IEnumerable<ZenjectResolveException> Validate();
+    }
+}

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/IValidatable.cs.meta
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/IValidatable.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fc785bec015c634a89f3b2d9dd4c6df
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/Instantiator.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/Instantiator.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/KeyedFactory.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/KeyedFactory.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using ModestTree.Zenject;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/KeyedFactory.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/KeyedFactory.cs
@@ -4,6 +4,7 @@ using ModestTree.Zenject;
 using System.Linq;
 using ModestTree.Zenject.Api;
 using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Injection/FieldsInjecter.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Injection/FieldsInjecter.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Injection/TypeAnalyzer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Injection/TypeAnalyzer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 using System.Linq;
 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/BindingValidator.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/BindingValidator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/DiContainer.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
@@ -1,17 +1,13 @@
-using System;
 using System.Collections.Generic;
-using UnityEngine;
-using System.Linq;
 
 namespace ModestTree.Zenject
 {
-    // We extract the interface so that monobehaviours can be installers
+    /// <summary>
+    ///     We extract the interface so that monobehaviours can be installers
+    /// </summary>
     public interface IInstaller
     {
-        DiContainer DiContainer
-        {
-            set;
-        }
+        DiContainer Container { set; }
 
         void InstallBindings();
 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/IInstaller.cs
@@ -8,7 +8,7 @@ namespace ModestTree.Zenject
     // We extract the interface so that monobehaviours can be installers
     public interface IInstaller
     {
-        DiContainer Container
+        DiContainer DiContainer
         {
             set;
         }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
@@ -1,20 +1,19 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
 
 namespace ModestTree.Zenject
 {
     public abstract class Installer : IInstaller
     {
-        protected DiContainer _container;
+        protected DiContainer Container;
 
         [Inject]
-        public DiContainer Container
+        public DiContainer DiContainer
         {
             set
             {
-                _container = value;
+                Container = value;
             }
         }
 
@@ -29,7 +28,7 @@ namespace ModestTree.Zenject
         // Helper method for ValidateSubGraphs
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return _container.ValidateObjectGraph<T>(extraTypes);
+            return Container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ModestTree.Zenject.Api;
 using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
@@ -6,15 +6,13 @@ namespace ModestTree.Zenject
 {
     public abstract class Installer : IInstaller
     {
-        protected DiContainer Container;
+        private DiContainer _container;
 
         [Inject]
-        public DiContainer DiContainer
+        public DiContainer Container
         {
-            set
-            {
-                Container = value;
-            }
+            set { _container = value; }
+            protected get { return _container; }
         }
 
         public abstract void InstallBindings();
@@ -25,10 +23,12 @@ namespace ModestTree.Zenject
             return Enumerable.Empty<ZenjectResolveException>();
         }
 
-        // Helper method for ValidateSubGraphs
+        /// <summary>
+        ///     Helper method for ValidateSubGraphs
+        /// </summary>
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return Container.ValidateObjectGraph<T>(extraTypes);
+            return _container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/Installer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
@@ -1,26 +1,19 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
+using UnityEngine;
 
 namespace ModestTree.Zenject
 {
     public abstract class MonoInstaller : MonoBehaviour, IInstaller
     {
-        protected DiContainer Container;
+        private DiContainer _container;
 
         [Inject]
-        public DiContainer DiContainer
+        public DiContainer Container
         {
-            set
-            {
-                Container = value;
-            }
-        }
-
-        public virtual void Start()
-        {
-            // Define this method so we expose the enabled check box
+            set { _container = value; }
+            protected get { return _container; }
         }
 
         public abstract void InstallBindings();
@@ -31,10 +24,17 @@ namespace ModestTree.Zenject
             return Enumerable.Empty<ZenjectResolveException>();
         }
 
-        // Helper method for ValidateSubGraphs
+        public virtual void Start()
+        {
+            // Define this method so we expose the enabled check box
+        }
+
+        /// <summary>
+        ///     Helper method for ValidateSubGraphs
+        /// </summary>
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return Container.ValidateObjectGraph<T>(extraTypes);
+            return _container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
@@ -7,14 +7,14 @@ namespace ModestTree.Zenject
 {
     public abstract class MonoInstaller : MonoBehaviour, IInstaller
     {
-        protected DiContainer _container;
+        protected DiContainer Container;
 
         [Inject]
-        public DiContainer Container
+        public DiContainer DiContainer
         {
             set
             {
-                _container = value;
+                Container = value;
             }
         }
 
@@ -34,7 +34,7 @@ namespace ModestTree.Zenject
         // Helper method for ValidateSubGraphs
         protected IEnumerable<ZenjectResolveException> Validate<T>(params Type[] extraTypes)
         {
-            return _container.ValidateObjectGraph<T>(extraTypes);
+            return Container.ValidateObjectGraph<T>(extraTypes);
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Main/MonoInstaller.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ModestTree.Zenject.Api;
 using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/DependencyRootStandard.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/DependencyRootStandard.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablePrioritiesInstaller.cs
@@ -6,7 +6,7 @@ namespace ModestTree.Zenject
 {
     public class DisposablePrioritiesInstaller : Installer
     {
-        List<Type> _disposables;
+        readonly List<Type> _disposables;
 
         public DisposablePrioritiesInstaller(List<Type> disposables)
         {
@@ -19,7 +19,7 @@ namespace ModestTree.Zenject
 
             foreach (var disposableType in _disposables)
             {
-                BindPriority(_container, disposableType, priorityCount);
+                BindPriority(Container, disposableType, priorityCount);
                 priorityCount++;
             }
         }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablesHandler.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablesHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ModestTree.Zenject.Api;
 using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablesHandler.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/DisposablesHandler.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/IInitializable.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/IInitializable.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Security.Permissions;
-
-namespace ModestTree.Zenject
+namespace ModestTree.Zenject.Api.Misc
 {
     public interface IInitializable
     {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/IKernel.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/IKernel.cs
@@ -1,12 +1,13 @@
-using System.Collections.Generic;
-using UnityEngine;
-using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {
-    // Interface for kernel class
-    // Currently there is only one (UnityKernel) but there should be another
-    // eventually, once Zenject adds support for non-unity projects
+    /// <summary>
+    ///     Interface for kernel class.
+    ///     Currently there is only one (UnityKernel) but there should be another eventually, once Zenject adds support for
+    ///     non-unity projects.
+    /// </summary>
     public interface IKernel
     {
         void AddTask(ITickable task);
@@ -15,4 +16,3 @@ namespace ModestTree.Zenject
         void RemoveTask(ITickable task);
     }
 }
-

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/ITickable.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/ITickable.cs
@@ -1,8 +1,4 @@
-using System.Collections.Generic;
-using UnityEngine;
-using System.Linq;
-
-namespace ModestTree.Zenject
+namespace ModestTree.Zenject.Api.Misc
 {
     public interface ITickable
     {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializableHandler.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializableHandler.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializablePrioritiesInstaller.cs
@@ -6,7 +6,7 @@ namespace ModestTree.Zenject
 {
     public class InitializablePrioritiesInstaller : Installer
     {
-        List<Type> _initializables;
+        readonly List<Type> _initializables;
 
         public InitializablePrioritiesInstaller(
             List<Type> initializables)
@@ -20,7 +20,7 @@ namespace ModestTree.Zenject
 
             foreach (var initializableType in _initializables)
             {
-                BindPriority(_container, initializableType, priorityCount);
+                BindPriority(Container, initializableType, priorityCount);
                 priorityCount++;
             }
         }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/InitializablePrioritiesInstaller.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/InjectAttribute.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/InjectAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ModestTree.Zenject
+namespace ModestTree.Zenject.Api.Misc
 {
     [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class InjectAttribute : Attribute

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/KernelUtil.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/KernelUtil.cs
@@ -1,4 +1,6 @@
 using System;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardKernel.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardKernel.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
+using ModestTree.Zenject.Api;
 using System.Linq;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardUnityInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardUnityInstaller.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardUnityInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/StandardUnityInstaller.cs
@@ -8,18 +8,18 @@ namespace ModestTree.Zenject
         // Install basic functionality for most unity apps
         public override void InstallBindings()
         {
-            _container.Bind<UnityKernel>().ToSingleGameObject();
+            Container.Bind<UnityKernel>().ToSingleGameObject();
 
-            _container.Bind<UnityEventManager>().ToSingleGameObject();
-            _container.Bind<GameObjectInstantiator>().ToSingle();
+            Container.Bind<UnityEventManager>().ToSingleGameObject();
+            Container.Bind<GameObjectInstantiator>().ToSingle();
 
-            _container.Bind<StandardKernel>().ToSingle();
+            Container.Bind<StandardKernel>().ToSingle();
             // TODO: Do this instead:
             //_container.Bind<IKernel>().ToTransient<StandardKernel>();
 
-            _container.Bind<InitializableHandler>().ToSingle();
-            _container.Bind<DisposablesHandler>().ToSingle();
-            _container.Bind<ITickable>().ToLookup<UnityEventManager>();
+            Container.Bind<InitializableHandler>().ToSingle();
+            Container.Bind<DisposablesHandler>().ToSingle();
+            Container.Bind<ITickable>().ToLookup<UnityEventManager>();
         }
     }
 }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/TickablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/TickablePrioritiesInstaller.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using ModestTree.Zenject;
+using ModestTree.Zenject.Api.Misc;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/TickablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/TickablePrioritiesInstaller.cs
@@ -6,7 +6,7 @@ namespace ModestTree.Zenject
 {
     public class TickablePrioritiesInstaller : Installer
     {
-        List<Type> _tickables;
+        readonly List<Type> _tickables;
 
         public TickablePrioritiesInstaller(
             List<Type> tickables)
@@ -20,7 +20,7 @@ namespace ModestTree.Zenject
 
             foreach (var tickableType in _tickables)
             {
-                BindPriority(_container, tickableType, priorityCount);
+                BindPriority(Container, tickableType, priorityCount);
                 priorityCount++;
             }
         }

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/UnityEventManager.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/UnityEventManager.cs
@@ -1,4 +1,6 @@
 using System;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/UnityKernel.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/UnityKernel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using ModestTree.Zenject.Api.Misc;
 using UnityEngine;
 using System.Linq;
 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/DiContainerProvider.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/DiContainerProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/GameObjectProvider.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/GameObjectProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/GameObjectSingletonProviderFromPrefab.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/GameObjectSingletonProviderFromPrefab.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/GameObjectTransientProviderFromPrefab.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/GameObjectTransientProviderFromPrefab.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+using ModestTree.Zenject.Api.Factories;
 using UnityEngine;
 
 namespace ModestTree.Zenject

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/InstanceProvider.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/InstanceProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/MethodProvider.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/MethodProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/ProviderBase.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/ProviderBase.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+
 namespace ModestTree.Zenject
 {
     public abstract class ProviderBase : IDisposable

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/SingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/SingletonProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/SingletonProviderMap.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/SingletonProviderMap.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
 
 namespace ModestTree.Zenject
 {

--- a/UnityProject/Assets/Zenject/Main/Scripts/Providers/TransientProvider.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Providers/TransientProvider.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ModestTree.Zenject.Api;
+using ModestTree.Zenject.Api.Exceptions;
+
 namespace ModestTree.Zenject
 {
     public class TransientProvider : ProviderBase

--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B71F2201-3382-46B3-A9C6-219A72954905}</ProjectGuid>
+    <ProjectGuid>{73A60B22-4135-4B72-9306-93263AAA9C2B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ModestTree.Zenject</RootNamespace>
-    <AssemblyName>Zenject-editor</AssemblyName>
+    <RootNamespace>ModestTree.Zenject.Api</RootNamespace>
+    <AssemblyName>Zenject.Api</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -41,30 +41,22 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEditor">
-      <HintPath>..\..\..\..\..\AssemblyBuild\Libraries\Unity\UnityEditor.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\AssemblyBuild\Libraries\Unity\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CompositionRootEditor.cs" />
-    <Compile Include="ObjectGraphVisualizer.cs" />
-    <Compile Include="ZenEditorUtil.cs" />
-    <Compile Include="ZenjectMenu.cs" />
+    <Compile Include="Exceptions\ZenjectException.cs">
+      <SubType>
+      </SubType>
+    </Compile>
+    <Compile Include="Factories\IFactory.cs" />
+    <Compile Include="Factories\IFactoryTyped.cs" />
+    <Compile Include="Factories\IValidatable.cs" />
+    <Compile Include="Misc\IInitializable.cs" />
+    <Compile Include="Misc\ITickable.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Scripts\Zenject.Api.csproj">
-      <Project>{73a60b22-4135-4b72-9306-93263aaa9c2b}</Project>
-      <Name>Zenject.Api</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Scripts\Zenject.csproj">
-      <Project>{46f25a62-2e29-48cb-95f3-bdbcb0976ddc}</Project>
-      <Name>Zenject</Name>
-    </ProjectReference>
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Factories\IFactoryTyped.cs" />
     <Compile Include="Factories\IValidatable.cs" />
     <Compile Include="Misc\IInitializable.cs" />
+    <Compile Include="Misc\InjectAttribute.cs" />
     <Compile Include="Misc\ITickable.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj.meta
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj.meta
@@ -1,0 +1,4 @@
+fileFormatVersion: 2
+guid: 02307f3b772699d4da83e97bc13ae907
+DefaultImporter:
+  userData: 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj.user
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectView>ProjectFiles</ProjectView>
+  </PropertyGroup>
+</Project>

--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj.user.meta
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.Api.csproj.user.meta
@@ -1,0 +1,4 @@
+fileFormatVersion: 2
+guid: fd2cb8c72914d004fb64c2f1e8769076
+DefaultImporter:
+  userData: 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.csproj
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.csproj
@@ -86,7 +86,6 @@
     <Compile Include="Misc\IKernel.cs" />
     <Compile Include="Misc\InitializableHandler.cs" />
     <Compile Include="Misc\InitializablePrioritiesInstaller.cs" />
-    <Compile Include="Misc\InjectAttribute.cs" />
     <Compile Include="Misc\KernelUtil.cs" />
     <Compile Include="Misc\LookupInProgressAdder.cs" />
     <Compile Include="Misc\StandardKernel.cs" />

--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.csproj
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{46F25A62-2E29-48CB-95F3-BDBCB0976DDC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Zenject</RootNamespace>
+    <RootNamespace>ModestTree.Zenject</RootNamespace>
     <AssemblyName>Zenject</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -58,14 +58,12 @@
     <Compile Include="Binders\InjectContext.cs" />
     <Compile Include="Binders\ReferenceBinder.cs" />
     <Compile Include="Binders\ValueBinder.cs" />
-    <Compile Include="Exceptions\ZenjectException.cs" />
     <Compile Include="Factories\Factory.cs" />
     <Compile Include="Factories\FactoryCustom.cs" />
     <Compile Include="Factories\FactoryMethod.cs" />
     <Compile Include="Factories\FactoryTyped.cs" />
     <Compile Include="Factories\GameObjectFactory.cs" />
     <Compile Include="Factories\GameObjectInstantiator.cs" />
-    <Compile Include="Factories\IFactory.cs" />
     <Compile Include="Factories\Instantiator.cs" />
     <Compile Include="Factories\KeyedFactory.cs" />
     <Compile Include="Factories\ListFactory.cs" />
@@ -76,19 +74,19 @@
     <Compile Include="Main\BindingValidator.cs" />
     <Compile Include="Main\CompositionRoot.cs" />
     <Compile Include="Main\DiContainer.cs" />
-    <Compile Include="Main\IInstaller.cs" />
+    <Compile Include="Main\IInstaller.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Main\Installer.cs" />
     <Compile Include="Main\MonoInstaller.cs" />
     <Compile Include="Misc\DependencyRootStandard.cs" />
     <Compile Include="Misc\DisposablePrioritiesInstaller.cs" />
     <Compile Include="Misc\DisposablesHandler.cs" />
     <Compile Include="Misc\IDependencyRoot.cs" />
-    <Compile Include="Misc\IInitializable.cs" />
     <Compile Include="Misc\IKernel.cs" />
     <Compile Include="Misc\InitializableHandler.cs" />
     <Compile Include="Misc\InitializablePrioritiesInstaller.cs" />
     <Compile Include="Misc\InjectAttribute.cs" />
-    <Compile Include="Misc\ITickable.cs" />
     <Compile Include="Misc\KernelUtil.cs" />
     <Compile Include="Misc\LookupInProgressAdder.cs" />
     <Compile Include="Misc\StandardKernel.cs" />
@@ -115,7 +113,12 @@
     <Compile Include="Util\TypeExtensions.cs" />
     <Compile Include="Util\UnityUtil.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="Zenject.Api.csproj">
+      <Project>{73a60b22-4135-4b72-9306-93263aaa9c2b}</Project>
+      <Name>Zenject.Api</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UnityProject/ProjectSettings/GraphicsSettings.asset
+++ b/UnityProject/ProjectSettings/GraphicsSettings.asset
@@ -3,5 +3,8 @@
 --- !u!30 &1
 GraphicsSettings:
   m_ObjectHideFlags: 0
+  serializedVersion: 2
   m_AlwaysIncludedShaders:
   - {fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10782, guid: 0000000000000000f000000000000000, type: 0}


### PR DESCRIPTION
If we use Zenject as assembly other assemblies can depend on it, for example usage of IFactory<>, however we should not provide full access to Zenject for these libraries, for example to DI container or other classes which should be used only in composition root. This is why there should be pure (no specific dependences) subproject with base types to eliminate possibility for other assemblies to depend on DI container.
