### PR TITLE
Adding IInstantiator to Zenject.csproj (assembly build solution)

### DIFF
--- a/UnityProject/Assets/Zenject/Main/Scripts/Zenject.csproj
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Zenject.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Main\GlobalCompositionRoot.cs" />
     <Compile Include="Main\GlobalInstallerConfig.cs" />
     <Compile Include="Main\IInstaller.cs" />
+    <Compile Include="Main\IInstantiator.cs" />
     <Compile Include="Main\Installer.cs" />
     <Compile Include="Main\MonoInstaller.cs" />
     <Compile Include="..\..\Internal\MiscExtensions.cs" />


### PR DESCRIPTION
The IInstantiator interface was left out of the Zenject Solution in the AssemblyBuild folder, so building that solution was failing. This just includes it and allows the dlls to be built again.
