### PR TITLE
Update GameObjectFactory.cs

### DIFF
--- a/UnityProject/Assets/Zenject/Main/Scripts/Factories/GameObjectFactory.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Factories/GameObjectFactory.cs
@@ -32,6 +32,22 @@ namespace Zenject
             return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), _prefab);
         }
 
+        public virtual TValue Create(GameObject prefab)
+        {
+           Assert.That(prefab != null,
+              "Null prefab given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), prefab);
+        }
+
+        public virtual TValue Create(string prefabResourceName)
+        {
+            Assert.That(!string.IsNullOrEmpty(prefabResourceName),
+              "Null or empty prefab resource name given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return Create((GameObject)Resources.Load(prefabResourceName));
+        }
+
         public override IEnumerable<ZenjectResolveException> Validate()
         {
             return _container.ValidateObjectGraph<TValue>();
@@ -51,6 +67,22 @@ namespace Zenject
         public virtual TValue Create(TParam1 param)
         {
             return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), _prefab, param);
+        }
+
+        public virtual TValue Create(GameObject prefab, TParam1 param)
+        {
+            Assert.That(prefab != null,
+               "Null prefab given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), prefab, param);
+        }
+
+        public virtual TValue Create(string prefabResourceName, TParam1 param)
+        {
+            Assert.That(!string.IsNullOrEmpty(prefabResourceName),
+              "Null or empty prefab resource name given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return Create((GameObject)Resources.Load(prefabResourceName), param);
         }
 
         public override IEnumerable<ZenjectResolveException> Validate()
@@ -74,6 +106,22 @@ namespace Zenject
             return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), _prefab, param1, param2);
         }
 
+        public virtual TValue Create(GameObject prefab, TParam1 param, TParam2 param2)
+        {
+            Assert.That(prefab != null,
+               "Null prefab given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), prefab, param, param2);
+        }
+
+        public virtual TValue Create(string prefabResourceName, TParam1 param, TParam2 param2)
+        {
+            Assert.That(!string.IsNullOrEmpty(prefabResourceName),
+              "Null or empty prefab resource name given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return Create((GameObject)Resources.Load(prefabResourceName), param, param2);
+        }
+
         public override IEnumerable<ZenjectResolveException> Validate()
         {
             return _container.ValidateObjectGraph<TValue>(typeof(TParam1), typeof(TParam2));
@@ -93,6 +141,22 @@ namespace Zenject
         public virtual TValue Create(TParam1 param1, TParam2 param2, TParam3 param3)
         {
             return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), _prefab, param1, param2, param3);
+        }
+
+        public virtual TValue Create(GameObject prefab, TParam1 param, TParam2 param2, TParam3 param3)
+        {
+            Assert.That(prefab != null,
+               "Null prefab given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), prefab, param, param2, param3);
+        }
+
+        public virtual TValue Create(string prefabResourceName, TParam1 param, TParam2 param2, TParam3 param3)
+        {
+            Assert.That(!string.IsNullOrEmpty(prefabResourceName),
+              "Null or empty prefab resource name given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return Create((GameObject)Resources.Load(prefabResourceName), param, param2, param3);
         }
 
         public override IEnumerable<ZenjectResolveException> Validate()
@@ -116,6 +180,22 @@ namespace Zenject
             return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), _prefab, param1, param2, param3, param4);
         }
 
+        public virtual TValue Create(GameObject prefab, TParam1 param, TParam2 param2, TParam3 param3, TParam4 param4)
+        {
+            Assert.That(prefab != null,
+               "Null prefab given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return (TValue)_container.InstantiatePrefabForComponent(typeof(TValue), prefab, param, param2, param3, param4);
+        }
+
+        public virtual TValue Create(string prefabResourceName, TParam1 param, TParam2 param2, TParam3 param3, TParam4 param4)
+        {
+            Assert.That(!string.IsNullOrEmpty(prefabResourceName),
+              "Null or empty prefab resource name given to factory create method when instantiating object with type '{0}'.", typeof(TValue));
+
+            return Create((GameObject)Resources.Load(prefabResourceName), param, param2, param3, param4);
+        }
+
         public override IEnumerable<ZenjectResolveException> Validate()
         {
             return _container.ValidateObjectGraph<TValue>(typeof(TParam1), typeof(TParam2), typeof(TParam3), typeof(TParam4));
@@ -124,4 +204,3 @@ namespace Zenject
 }
 
 #endif
-


### PR DESCRIPTION
Added ability to game object factory to instantiate game objects from prefab or from resource, not just from default prefab bound in the installer.

Usage example in hypothetical Asteroid spawner:

[Inject]
private EnemyPresenter.Factory enemyPresenterFactory;
//asteroid prefabs with different 3D models
public GameObject[] asteroids;

...

var randomNumber = UnityEngine.Random.Range(0, asteroids.Length);
GameObject asteroid = asteroids[randomNumber];
enemyPresenterFactory.Create(asteroid);
