### PR TITLE
Default parameter value implies that the parameter is optional even when not annotated with the `InjectOptional` attribute.

### DIFF
--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Editor/TestConstructorInjectionOptional.cs
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Editor/TestConstructorInjectionOptional.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Zenject;
+using NUnit.Framework;
+using ModestTree;
+using Assert=ModestTree.Assert;
+
+namespace Zenject.Tests
+{
+    [TestFixture]
+    public class TestConstructorInjectionOptional : TestWithContainer
+    {
+        private class Test1
+        {
+        }
+
+        private class Test2
+        {
+            public Test1 val;
+
+            public Test2(Test1 val = null)
+            {
+                this.val = val;
+            }
+        }
+
+        private class Test3
+        {
+            public Test1 val;
+
+            public Test3(Test1 val)
+            {
+                this.val = val;
+            }
+        }
+
+        [Test]
+        public void TestCase1()
+        {
+            Container.Bind<Test2>().ToSingle();
+
+            Assert.That(Container.ValidateResolve<Test2>().IsEmpty());
+            var test1 = Container.Resolve<Test2>();
+
+            Assert.That(test1.val == null);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ZenjectResolveException))]
+        public void TestCase2()
+        {
+            Container.Bind<Test3>().ToSingle();
+
+            var test1 = Container.Instantiate<Test3>();
+
+            Assert.That(test1.val == null);
+        }
+
+        [Test]
+        public void TestConstructByFactory()
+        {
+            Container.Bind<Test2>().ToSingle();
+
+            var test1 = Container.Instantiate<Test2>();
+
+            Assert.That(test1.val == null);
+        }
+    }
+}
+
+

--- a/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Editor/TestConstructorInjectionOptional.cs.meta
+++ b/UnityProject/Assets/Zenject/Extras/ZenjectUnitTests/Editor/TestConstructorInjectionOptional.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2d17e02fd5acf54468fd48da7716d600
+timeCreated: 1442021941
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/Main/Scripts/Injection/TypeAnalyzer.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Injection/TypeAnalyzer.cs
@@ -73,7 +73,7 @@ namespace Zenject
             }
 
             return new InjectableInfo(
-                injectOptionalAttributes.Any(),
+                paramInfo.IsOptional || injectOptionalAttributes.Any(),
                 identifier,
                 paramInfo.Name,
                 paramInfo.ParameterType,


### PR DESCRIPTION
In relation to issue #49.
