### PR TITLE
Updated for 5.3

### DIFF
--- a/UnityProject/Assets/Zenject/Main/Editor/ZenEditorUtil.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenEditorUtil.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using ModestTree;
+using UnityEditor.SceneManagement;
 
 namespace Zenject
 {
@@ -53,7 +54,7 @@ namespace Zenject
             {
                 Log.Trace("Validating Scene '{0}'", sceneInfo.Path);
 #if UNITY_5_3
-				EditorSceneManager.OpenScene(sceneInfo.Path, false);
+				EditorSceneManager.OpenScene(sceneInfo.Path, OpenSceneMode.Single);
 #else
 				EditorApplication.OpenScene(sceneInfo.Path);
 #endif

--- a/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
+++ b/UnityProject/Assets/Zenject/Main/Editor/ZenjectMenu.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using System.Linq;
 using Debug = UnityEngine.Debug;
 using ModestTree;
+using UnityEditor.SceneManagement;
 
 namespace Zenject
 {
@@ -55,7 +56,7 @@ namespace Zenject
                 Log.Trace("Validating scene '{0}'...", sceneInfo.Name);
 
 #if UNITY_5_3
-				EditorSceneManager.OpenScene(sceneInfo.Path, false);
+				EditorSceneManager.OpenScene(sceneInfo.Path, OpenSceneMode.Single);
 #else
 				EditorApplication.OpenScene(sceneInfo.Path);
 #endif
@@ -74,7 +75,7 @@ namespace Zenject
             }
 
 #if UNITY_5_3
-			EditorSceneManager.OpenScene(startScene, false);
+			EditorSceneManager.OpenScene(startScene, OpenSceneMode.Single);
 #else
 			EditorApplication.OpenScene(startScene);
 #endif
@@ -126,7 +127,7 @@ namespace Zenject
             try
             {
 #if UNITY_5_3
-				EditorSceneManager.OpenScene(scenePath, true);
+				EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
 #else
 				EditorApplication.OpenSceneAdditive(scenePath);
 #endif

--- a/UnityProject/Assets/Zenject/Main/Scripts/Misc/ZenUtil.cs
+++ b/UnityProject/Assets/Zenject/Main/Scripts/Misc/ZenUtil.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Diagnostics;
 using ModestTree;
 using ModestTree.Util;
-
+using UnityEngine.SceneManagement;
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;
 #endif
@@ -77,7 +77,7 @@ namespace Zenject
 
 #if UNITY_5_3
             Log.Debug("Starting to load scene '{0}'", levelName);
-			SceneManager.LoadScene(levelName, isAdditive);
+			SceneManager.LoadScene(levelName, isAdditive ? LoadSceneMode.Additive : LoadSceneMode.Single);
             Log.Debug("Finished loading scene '{0}'", levelName);
 #else
 			if (isAdditive)
@@ -102,7 +102,7 @@ namespace Zenject
             var rootObjectsBeforeLoad = UnityUtil.GetRootGameObjects();
 
 #if UNITY_5_3
-			SceneManager.LoadScene(levelName, true);
+			SceneManager.LoadScene(levelName, LoadSceneMode.Additive);
 #else
 			Application.LoadLevelAdditive(levelName);
 #endif


### PR DESCRIPTION
Unity's official 5.3 release added in some new enums on the SceneManagement side, so Unity throws some obsolete warnings with Zenject.  I went and updated it from the bools of the 5.3 beta to the enums.

I'm still extremely new with using Zenject (just finished the tutorial) so I'm not sure if these introduced any bugs, but it seemed trivial enough and everything's been working fine on my end.
