### PR TITLE
Fix issue where valid instances would fail the "instance of" check

### DIFF
--- a/UnityProject/Assets/Zenject/Source/Binders/UntypedBinder.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/UntypedBinder.cs
@@ -69,12 +69,12 @@ namespace Zenject
 
         public BindingConditionSetter ToSingleInstance<TConcrete>(TConcrete instance)
         {
-            return ToSingleInstance(typeof(TConcrete), null, instance);
+            return ToSingleInstance(instance != null ? instance.GetType() : typeof(TConcrete), null, instance);
         }
 
         public BindingConditionSetter ToSingleInstance<TConcrete>(string concreteIdentifier, TConcrete instance)
         {
-            return ToSingleInstance(typeof(TConcrete), concreteIdentifier, instance);
+            return ToSingleInstance(instance != null ? instance.GetType() : typeof(TConcrete), concreteIdentifier, instance);
         }
 
         public BindingConditionSetter ToSingleMethod<TConcrete>(string concreteIdentifier, Func<InjectContext, TConcrete> method)

--- a/UnityProject/Assets/Zenject/Source/Binders/UntypedBinder.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/UntypedBinder.cs
@@ -64,7 +64,7 @@ namespace Zenject
 
         public BindingConditionSetter ToInstance<TConcrete>(TConcrete instance)
         {
-            return ToInstance(typeof(TConcrete), instance);
+            return ToInstance(instance != null ? instance.GetType() : typeof(TConcrete), instance);
         }
 
         public BindingConditionSetter ToSingleInstance<TConcrete>(TConcrete instance)


### PR DESCRIPTION
Added a conditional check to both `ToSingleInstance` methods to use the run-time type of the provided instance instead of the generic type if the instance is not `null`.

Condition of failure.

``` csharp
public class Foo
{

}

public class Bar : Foo
{

{

Type type = typeof(Bar);
Foo barInstance = new Bar();
Container.Bind(type).ToSingleInstance(barInstance);
// the compiler sees this as ToSingleInstance<Foo>(barInstance);
```

The above code attempts to check if `Foo` extends `Bar` even tho the instance given is of type `Bar` and should be aloud to bind.
