### PR TITLE
Removing unused using statements, to avoid warnings created within VS Code

### DIFF
--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Binders/CommandBinder.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Binders/CommandBinder.cs
@@ -1,9 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using ModestTree;
-using ModestTree.Util;
-using System.Linq;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Command/Command.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Command/Command.cs
@@ -1,4 +1,3 @@
-using ModestTree.Util;
 using System;
 
 namespace Zenject.Commands

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Command/CommandExtensions.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Command/CommandExtensions.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
-using ModestTree.Util;
-
 namespace Zenject.Commands
 {
     public static class CommandExtensions

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Command/ICommandHandler.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Command/ICommandHandler.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Zenject.Commands
 {
     public interface ICommandHandlerBase

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderBase.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderBase.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using ModestTree;
-using System.Linq;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderHandlerSingle.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderHandlerSingle.cs
@@ -1,9 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using ModestTree;
-using ModestTree.Util;
-using System.Linq;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderHandlerTransient.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderHandlerTransient.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using ModestTree;
-using System.Linq;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderMethodSingle.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderMethodSingle.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using ModestTree;
-using ModestTree.Util;
-using System.Linq;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderMethodTransient.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderMethodTransient.cs
@@ -1,9 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using ModestTree;
-using ModestTree.Util;
-using System.Linq;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderSingle.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderSingle.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
-using ModestTree;
 using System.Linq;
 
 namespace Zenject.Commands

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderStatic.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderStatic.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using ModestTree;
-using System.Linq;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderTransient.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Providers/CommandProviderTransient.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
-using ModestTree;
 using System.Linq;
 
 namespace Zenject.Commands

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Signal/Signal.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Signal/Signal.cs
@@ -1,5 +1,4 @@
 using System;
-using ModestTree.Util;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Signal/SignalExtensions.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/CommandsAndSignals/Signal/SignalExtensions.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject.Commands
 {

--- a/UnityProject/Assets/Zenject/Source/Binders/BinderBase.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/BinderBase.cs
@@ -1,8 +1,5 @@
 using System;
 using ModestTree;
-#if !ZEN_NOT_UNITY3D
-using UnityEngine;
-#endif
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Binders/BindingConditionSetter.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/BindingConditionSetter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using ModestTree;
 

--- a/UnityProject/Assets/Zenject/Source/Binders/GenericBinder.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/GenericBinder.cs
@@ -1,5 +1,4 @@
 using System;
-using ModestTree;
 
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Binders/IFactoryBinder.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/IFactoryBinder.cs
@@ -1,6 +1,5 @@
 using System;
 using ModestTree;
-using ModestTree.Util;
 
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Binders/IFactoryUntypedBinder.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/IFactoryUntypedBinder.cs
@@ -1,10 +1,4 @@
 using System;
-using ModestTree;
-using ModestTree.Util;
-
-#if !ZEN_NOT_UNITY3D
-using UnityEngine;
-#endif
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Binders/UntypedBinder.cs
+++ b/UnityProject/Assets/Zenject/Source/Binders/UntypedBinder.cs
@@ -1,6 +1,5 @@
 using System;
 using ModestTree;
-using ModestTree.Util;
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;
 #endif

--- a/UnityProject/Assets/Zenject/Source/Editor/ObjectGraphVisualizer.cs
+++ b/UnityProject/Assets/Zenject/Source/Editor/ObjectGraphVisualizer.cs
@@ -1,10 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Diagnostics;
-using UnityEngine;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Editor/SceneCompositionRootEditor.cs
+++ b/UnityProject/Assets/Zenject/Source/Editor/SceneCompositionRootEditor.cs
@@ -1,11 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
-using Zenject;
 using UnityEditor;
-using UnityEditorInternal;
-using UnityEngine;
-using Object = UnityEngine.Object;
-using ModestTree;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Editor/SceneDecoratorCompositionRootEditor.cs
+++ b/UnityProject/Assets/Zenject/Source/Editor/SceneDecoratorCompositionRootEditor.cs
@@ -4,11 +4,9 @@ using System.Linq;
 using UnityEditor.SceneManagement;
 #endif
 using ModestTree.Util;
-using Zenject;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
-using Object = UnityEngine.Object;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Editor/UnityInspectorListEditor.cs
+++ b/UnityProject/Assets/Zenject/Source/Editor/UnityInspectorListEditor.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
-using Zenject;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
-using Object = UnityEngine.Object;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Facade/Facade.cs
+++ b/UnityProject/Assets/Zenject/Source/Facade/Facade.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Facade/FacadeFactory.cs
+++ b/UnityProject/Assets/Zenject/Source/Facade/FacadeFactory.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Facade/IFacade.cs
+++ b/UnityProject/Assets/Zenject/Source/Facade/IFacade.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Factories/FactoryMethod.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/FactoryMethod.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Factories/FactoryNested.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/FactoryNested.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace Zenject
 {
     // We don't bother implementing IValidatable here because it is assumed that the nested

--- a/UnityProject/Assets/Zenject/Source/Factories/FactoryUntyped.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/FactoryUntyped.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Factories/GameObjectFactory.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/GameObjectFactory.cs
@@ -1,6 +1,5 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
 using System.Collections.Generic;
 using ModestTree;
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Factories/GameObjectInstantiator.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/GameObjectInstantiator.cs
@@ -1,10 +1,5 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
-using System.Collections.Generic;
-using ModestTree;
-using UnityEngine;
-
 namespace Zenject
 {
     public class GameObjectInstantiator

--- a/UnityProject/Assets/Zenject/Source/Factories/IFactory.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/IFactory.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Zenject
 {
     public interface IFactory

--- a/UnityProject/Assets/Zenject/Source/Factories/IFactoryUntyped.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/IFactoryUntyped.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Factories/IValidatable.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/IValidatable.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Factories/IValidatableFactory.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/IValidatableFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Factories/KeyedFactory.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/KeyedFactory.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Zenject;
-using ModestTree.Util;
 using ModestTree;
 using System.Linq;
 

--- a/UnityProject/Assets/Zenject/Source/Factories/ListFactory.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/ListFactory.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Zenject;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Factories/PrefabFactory.cs
+++ b/UnityProject/Assets/Zenject/Source/Factories/PrefabFactory.cs
@@ -1,9 +1,5 @@
 ﻿#if !ZEN_NOT_UNITY3D
 
-using System;
-using System.Collections.Generic;
-using Zenject;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Injection/InjectableInfo.cs
+++ b/UnityProject/Assets/Zenject/Source/Injection/InjectableInfo.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Injection/TypeAnalyzer.cs
+++ b/UnityProject/Assets/Zenject/Source/Injection/TypeAnalyzer.cs
@@ -4,10 +4,6 @@ using System.Reflection;
 using System.Linq;
 using ModestTree;
 
-#if !ZEN_NOT_UNITY3D
-using UnityEngine;
-#endif
-
 namespace Zenject
 {
     internal static class TypeAnalyzer

--- a/UnityProject/Assets/Zenject/Source/Injection/ZenjectTypeInfo.cs
+++ b/UnityProject/Assets/Zenject/Source/Injection/ZenjectTypeInfo.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Linq;
-using ModestTree;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Internal/Assert.cs
+++ b/UnityProject/Assets/Zenject/Source/Internal/Assert.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using Zenject;
 
 namespace ModestTree

--- a/UnityProject/Assets/Zenject/Source/Internal/Func.cs
+++ b/UnityProject/Assets/Zenject/Source/Internal/Func.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace ModestTree.Util
 {
     // C# 3.5 only defines Func and Action to a maximum of 4 generic parameters

--- a/UnityProject/Assets/Zenject/Source/Internal/Log.cs
+++ b/UnityProject/Assets/Zenject/Source/Internal/Log.cs
@@ -1,14 +1,5 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
-
-#if !ZEN_NOT_UNITY3D
-using UnityEngine;
-#endif
 
 namespace ModestTree
 {

--- a/UnityProject/Assets/Zenject/Source/Internal/ProfileBlock.cs
+++ b/UnityProject/Assets/Zenject/Source/Internal/ProfileBlock.cs
@@ -1,13 +1,6 @@
 //#define PROFILING_ENABLED
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text.RegularExpressions;
-
-#if !ZEN_NOT_UNITY3D
-using UnityEngine;
-#endif
 
 namespace ModestTree.Util.Debugging
 {

--- a/UnityProject/Assets/Zenject/Source/Internal/ReflectionUtil.cs
+++ b/UnityProject/Assets/Zenject/Source/Internal/ReflectionUtil.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 
 namespace ModestTree.Util
 {

--- a/UnityProject/Assets/Zenject/Source/Internal/Tuple.cs
+++ b/UnityProject/Assets/Zenject/Source/Internal/Tuple.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace ModestTree.Util
 {

--- a/UnityProject/Assets/Zenject/Source/Main/BindingId.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/BindingId.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Main/CompositionRoot.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/CompositionRoot.cs
@@ -1,16 +1,8 @@
 #if !ZEN_NOT_UNITY3D
 
 #pragma warning disable 414
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
-using ModestTree.Util;
 using UnityEngine;
-
-#if UNITY_5_3_OR_NEWER
-using UnityEngine.SceneManagement;
-#endif
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Main/GlobalCompositionRoot.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/GlobalCompositionRoot.cs
@@ -3,7 +3,6 @@
 #pragma warning disable 414
 using ModestTree;
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Main/GlobalInstallerConfig.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/GlobalInstallerConfig.cs
@@ -1,6 +1,5 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Main/IBinder.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/IBinder.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
-using ModestTree.Util;
 
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Main/IInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/IInstaller.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Zenject
 {
     // We extract the interface so that monobehaviours can be installers

--- a/UnityProject/Assets/Zenject/Source/Main/IInstantiator.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/IInstantiator.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
 
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Main/IResolver.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/IResolver.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
-using ModestTree.Util;
 
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Main/Installer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/Installer.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Zenject
 {
     [System.Diagnostics.DebuggerStepThrough]

--- a/UnityProject/Assets/Zenject/Source/Main/MonoInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/MonoInstaller.cs
@@ -1,8 +1,5 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Main/SingletonId.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/SingletonId.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Main/SingletonRegistry.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/SingletonRegistry.cs
@@ -1,13 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
-using ModestTree.Util;
-
-#if !ZEN_NOT_UNITY3D
-using UnityEngine;
-#endif
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/DisposableManager.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/DisposableManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/ExecutionOrderInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/ExecutionOrderInstaller.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Zenject;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/FixedTickablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/FixedTickablePrioritiesInstaller.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Zenject;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/IInitializable.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/IInitializable.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Reflection;
-
 namespace Zenject
 {
     public interface IInitializable

--- a/UnityProject/Assets/Zenject/Source/Misc/ITickable.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/ITickable.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/InitializableManager.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/InitializableManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/KernelUtil.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/KernelUtil.cs
@@ -1,6 +1,4 @@
 using System;
-using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/LateTickablePrioritiesInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/LateTickablePrioritiesInstaller.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Zenject;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/StandardInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/StandardInstaller.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-
 namespace Zenject
 {
     public class StandardInstaller<TRoot> : Installer

--- a/UnityProject/Assets/Zenject/Source/Misc/TaskUpdater.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/TaskUpdater.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using ModestTree.Util;
 using System.Linq;
 using ModestTree;
 

--- a/UnityProject/Assets/Zenject/Source/Misc/TickableManager.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/TickableManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ModestTree;
-using ModestTree.Util;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Misc/UnityEventManager.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/UnityEventManager.cs
@@ -1,7 +1,6 @@
 #if !ZEN_NOT_UNITY3D
 
 using System;
-using ModestTree.Util;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Misc/ZenUtil.cs
+++ b/UnityProject/Assets/Zenject/Source/Misc/ZenUtil.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Diagnostics;
 using ModestTree;
 using ModestTree.Util;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/DiContainerProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/DiContainerProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/GameObjectTransientProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/GameObjectTransientProvider.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/GameObjectTransientProviderFromPrefab.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/GameObjectTransientProviderFromPrefab.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/GameObjectTransientProviderFromPrefabResource.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/GameObjectTransientProviderFromPrefabResource.cs
@@ -2,9 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
-using UnityEngine;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/ResourceProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/ResourceProvider.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/FactorySingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/FactorySingletonLazyCreator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using ModestTree;

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/FactorySingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/FactorySingletonProvider.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using ModestTree;
-using System.Linq;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/FactorySingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/FactorySingletonProviderCreator.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/IFactorySingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Factory/IFactorySingletonLazyCreator.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/GameObject/GameObjectSingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/GameObject/GameObjectSingletonLazyCreator.cs
@@ -1,9 +1,7 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
 using System.Collections.Generic;
 using ModestTree;
-using System.Linq;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/GameObject/GameObjectSingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/GameObject/GameObjectSingletonProvider.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/GameObject/GameObjectSingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/GameObject/GameObjectSingletonProviderCreator.cs
@@ -2,9 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
-using ModestTree.Util;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Instance/InstanceSingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Instance/InstanceSingletonLazyCreator.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Instance/InstanceSingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Instance/InstanceSingletonProvider.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using ModestTree;
-using System.Linq;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Instance/InstanceSingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Instance/InstanceSingletonProviderCreator.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/IMethodSingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/IMethodSingletonLazyCreator.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using ModestTree;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/MethodSingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/MethodSingletonLazyCreator.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/MethodSingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/MethodSingletonProvider.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using ModestTree;
-using System.Linq;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/MethodSingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Method/MethodSingletonProviderCreator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonId.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonId.cs
@@ -1,8 +1,6 @@
 #if !ZEN_NOT_UNITY3D
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonLazyCreator.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using ModestTree;
-using System.Linq;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonProvider.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/MonoBehaviour/MonoBehaviourSingletonProviderCreator.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonId.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonId.cs
@@ -1,8 +1,6 @@
 #if !ZEN_NOT_UNITY3D
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonLazyCreator.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using ModestTree;
-using System.Linq;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonProvider.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Prefab/PrefabSingletonProviderCreator.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonId.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonId.cs
@@ -1,10 +1,7 @@
 #if !ZEN_NOT_UNITY3D
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
-using UnityEngine;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonLazyCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonLazyCreator.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using ModestTree;
-using System.Linq;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonProvider.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 using UnityEngine;
 

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/PrefabResource/PrefabResourceSingletonProviderCreator.cs
@@ -2,9 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
-using UnityEngine;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/SingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/SingletonProviderCreator.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using ModestTree;
 
 #if !ZEN_NOT_UNITY3D
 using UnityEngine;

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Type/TypeSingletonProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Type/TypeSingletonProvider.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using ModestTree;
-using System.Linq;
 
 namespace Zenject
 {

--- a/UnityProject/Assets/Zenject/Source/Providers/Singleton/Type/TypeSingletonProviderCreator.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/Singleton/Type/TypeSingletonProviderCreator.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Providers/TransientProvider.cs
+++ b/UnityProject/Assets/Zenject/Source/Providers/TransientProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Util/AutoBindInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Util/AutoBindInstaller.cs
@@ -1,9 +1,6 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 using ModestTree;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Util/DecoratorInstaller.cs
+++ b/UnityProject/Assets/Zenject/Source/Util/DecoratorInstaller.cs
@@ -1,6 +1,5 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Util/SceneDecoratorCompositionRoot.cs
+++ b/UnityProject/Assets/Zenject/Source/Util/SceneDecoratorCompositionRoot.cs
@@ -1,10 +1,7 @@
 #if !ZEN_NOT_UNITY3D
 
 using System;
-using System.Collections;
-using System.Linq;
 using ModestTree;
-using ModestTree.Util;
 using UnityEngine;
 
 namespace Zenject

--- a/UnityProject/Assets/Zenject/Source/Util/UnityUtil.cs
+++ b/UnityProject/Assets/Zenject/Source/Util/UnityUtil.cs
@@ -1,6 +1,5 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;

--- a/UnityProject/Assets/Zenject/Source/Util/ZenjectAutoBinding.cs
+++ b/UnityProject/Assets/Zenject/Source/Util/ZenjectAutoBinding.cs
@@ -1,7 +1,5 @@
 #if !ZEN_NOT_UNITY3D
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using ModestTree;


### PR DESCRIPTION
VS Code displays warnings for unused using statements.  This cleans up the unused ones in Zenject, so that it doesn't create lots of warnings in the parent Unity project.
