### PR TITLE
Modified ResolveTypeAll() to find types in parent containers

### DIFF
--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -465,11 +465,11 @@ namespace Zenject
             FlushBindings();
             CheckForInstallWarning(context);
 
-			var providers = GetProviderMatchesInternal(context).ToList();
-			if (providers.Count > 0 )
-			{
-				return providers.Select(x => x.ProviderInfo.Provider.GetInstanceType(context)).Where(x => x != null).ToList();
-			}
+            var providers = GetProviderMatchesInternal(context).ToList();
+            if (providers.Count > 0 )
+            {
+            	return providers.Select(x => x.ProviderInfo.Provider.GetInstanceType(context)).Where(x => x != null).ToList();
+            }
 
             return new List<Type> {};
         }

--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -465,12 +465,11 @@ namespace Zenject
             FlushBindings();
             CheckForInstallWarning(context);
 
-            var bindingId = context.GetBindingId();
-
-            if (_providers.ContainsKey(bindingId))
-            {
-                return _providers[bindingId].Select(x => x.Provider.GetInstanceType(context)).Where(x => x != null).ToList();
-            }
+			var providers = GetProviderMatchesInternal(context).ToList();
+			if (providers.Count > 0 )
+			{
+				return providers.Select(x => x.ProviderInfo.Provider.GetInstanceType(context)).Where(x => x != null).ToList();
+			}
 
             return new List<Type> {};
         }


### PR DESCRIPTION
I don't know if it was intentional or not, but in case it wasn't here's a possible "fix" to DiContainer to find types that are bound in parent containers.
