### PR TITLE
fixed Incomplete assert with unresolved generic dependency #172

### DIFF
--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -570,7 +570,7 @@ namespace Zenject
                 }
 
                 throw Assert.CreateException("Unable to resolve type '{0}'{1}. \nObject graph:\n{2}",
-                    context.MemberType.Name() + (context.Identifier == null ? "" : " with ID '{0}'".Fmt(context.Identifier.ToString())),
+                    context.MemberType + (context.Identifier == null ? "" : " with ID '{0}'".Fmt(context.Identifier.ToString())),
                     (context.ObjectType == null ? "" : " while building object with type '{0}'".Fmt(context.ObjectType.Name())),
                     context.GetObjectGraphString());
             }


### PR DESCRIPTION
Instead of 
```ZenjectException: Unable to resolve type 'Foo`1' while building object with type 'FooRequester'. ```
there is now
```ZenjectException: Unable to resolve type 'Foo`1[Bar]' while building object with type 'FooRequester'. ```