### PR TITLE
Fixed instantiate misbehaviour

### DIFF
--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -1199,10 +1199,6 @@ namespace Zenject
 
             gameObj.transform.SetParent(GetTransformGroup(gameObjectBindInfo), false);
 
-            if (prefabAsGameObject.activeSelf) {
-                gameObj.SetActive(true);
-            }
-
             return InjectGameObjectForComponentExplicit(
                 gameObj, componentType, args);
         }

--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -1193,10 +1193,15 @@ namespace Zenject
             Assert.That(componentType.IsInterface() || componentType.DerivesFrom<Component>(),
                 "Expected type '{0}' to derive from UnityEngine.Component", componentType.Name());
 
-            var gameObj = (GameObject)GameObject.Instantiate(GetPrefabAsGameObject(prefab));
+			GameObject prefabAsGameObject = GetPrefabAsGameObject(prefab);
+
+			var gameObj = (GameObject)GameObject.Instantiate(prefabAsGameObject);
 
             gameObj.transform.SetParent(GetTransformGroup(gameObjectBindInfo), false);
-            gameObj.SetActive(true);
+
+			if (prefabAsGameObject.activeSelf) {
+				gameObj.SetActive(true);
+			}
 
             return InjectGameObjectForComponentExplicit(
                 gameObj, componentType, args);

--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -1193,15 +1193,15 @@ namespace Zenject
             Assert.That(componentType.IsInterface() || componentType.DerivesFrom<Component>(),
                 "Expected type '{0}' to derive from UnityEngine.Component", componentType.Name());
 
-			GameObject prefabAsGameObject = GetPrefabAsGameObject(prefab);
+            GameObject prefabAsGameObject = GetPrefabAsGameObject(prefab);
 
-			var gameObj = (GameObject)GameObject.Instantiate(prefabAsGameObject);
+            var gameObj = (GameObject)GameObject.Instantiate(prefabAsGameObject);
 
             gameObj.transform.SetParent(GetTransformGroup(gameObjectBindInfo), false);
 
-			if (prefabAsGameObject.activeSelf) {
-				gameObj.SetActive(true);
-			}
+            if (prefabAsGameObject.activeSelf) {
+                gameObj.SetActive(true);
+            }
 
             return InjectGameObjectForComponentExplicit(
                 gameObj, componentType, args);


### PR DESCRIPTION
If the programmer instantiate a prefab object that was disabled intentionally, the Zenject's instantiate function is activing them even though the programmer don't want to.

I was refactoring a really big game and wanted to apply IoC, Zenject was the right choice. Once I started refactoring it, I found a case of a component that had to access the parent inside the OnEnable function, at first, I thought it was wrong, but them, I realized that even though it was wrong Zenject shouldn't break because of it. The prefab was saved disabled and it was activated after the instance parenting.

Probably there are other cases of side effects from this behaviour.