### PR TITLE
Add unit tests for Instantiate using local coordinates when parenting

### DIFF
--- a/UnityProject/Assets/Plugins/UniRx.meta
+++ b/UnityProject/Assets/Plugins/UniRx.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 999a0d9a55b592a4aa0610b2d6a93b1f
-folderAsset: yes
-timeCreated: 1487190634
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/Bindings/Editor/TestDiContainerMethods.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/Bindings/Editor/TestDiContainerMethods.cs
@@ -226,6 +226,38 @@ namespace Zenject.Tests.Bindings
             Assert.That(Qux.WasInjected);
         }
 
+        [Test]
+        public void TestInstantiatePrefabForComponentExplicit()
+        {
+            Initialize();
+
+            var parentGameObject = new GameObject();
+            parentGameObject.transform.position = new Vector3(100, 100, 100);
+            var parentTransform = parentGameObject.transform;
+
+            var go = (Foo)Container.InstantiatePrefabForComponentExplicit(typeof(Foo), FooPrefab, new List<TypeValuePair>(), new GameObjectCreationParameters() { ParentTransform = parentTransform });
+
+            var foo = go.GetComponentInChildren<Foo>();
+
+            Assert.IsEqual(foo.transform.position, new Vector3(100, 100, 100));
+        }
+
+        [Test]
+        public void TestCreateAndParentPrefab()
+        {
+            Initialize();
+
+            var parentGameObject = new GameObject();
+            parentGameObject.transform.position = new Vector3(100, 100, 100);
+            var parentTransform = parentGameObject.transform;
+
+            var go = Container.CreateAndParentPrefab(FooPrefab, new GameObjectCreationParameters() { ParentTransform = parentTransform });
+
+            var foo = go.GetComponentInChildren<Foo>();
+
+            Assert.IsEqual(foo.transform.position, new Vector3(100, 100, 100));
+        }
+
         public class Qux
         {
             public static bool WasInjected

--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -2162,7 +2162,7 @@ namespace Zenject
             GameObject prefabAsGameObject = GetPrefabAsGameObject(prefab);
 
             var gameObj = (GameObject)GameObject.Instantiate(
-                prefabAsGameObject, GetTransformGroup(gameObjectBindInfo));
+                prefabAsGameObject, GetTransformGroup(gameObjectBindInfo), false);
 
             return InjectGameObjectForComponentExplicit(
                 gameObj, componentType, args);


### PR DESCRIPTION
This adds unit tests to confirm that the use of `GameObject.Instantiate` is using local coordinates for child objects when a parent is set. It also fixes this behavior in the `InstantiatePrefabForComponentExplicit`.

Relates to #204.