### PR TITLE
Minor fix to strip () before . in ZenjectIntegrationTestFixture:Curre…

### DIFF
--- a/UnityProject/Assets/Zenject/Source/Editor/Testing/ZenjectIntegrationTestFixture.cs
+++ b/UnityProject/Assets/Zenject/Source/Editor/Testing/ZenjectIntegrationTestFixture.cs
@@ -85,8 +85,8 @@ namespace Zenject
         bool CurrentTestHasAttribute<T>()
             where T : Attribute
         {
-            var fullMethodName = TestContext.CurrentContext.Test.FullName;
-            var name = fullMethodName.Substring(fullMethodName.LastIndexOf(".")+1);
+            // tests with double parameters need to have their () removed first
+            var name = TestContext.CurrentContext.Test.FullName;
 
             // Remove all characters after the first open bracket if there is one
             int openBracketIndex = name.IndexOf("(");
@@ -95,6 +95,9 @@ namespace Zenject
             {
                 name = name.Substring(0, openBracketIndex);
             }
+
+            // Now we can get the substring starting at the last '.'
+            name = name.Substring(name.LastIndexOf(".") + 1);
 
             return this.GetType().GetMethod(name).GetCustomAttributes(true)
                 .Cast<Attribute>().OfType<T>().Any();


### PR DESCRIPTION
Fixes Issue #221: In the CurrentTestHasAttribute<T> method, you get the method name by taking the full name, stripping off everything before the last dot & then removing the parens at the end (if they exist). However, if you're using parameterized tests which have doubles (as I am), the full name of the test will have a dot within the parens, e.g. Parameterized_Double_Test(1.653442234d). The fix is simple: just strip the parens before getting everything after the last dot.