### PR TITLE
Add Pause/Resume parenting for TickableManager - fixes #182

### DIFF
--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 66c9b56a34bc59f4ba3a274404ef9ea6
+folderAsset: yes
+timeCreated: 1489865317
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Editor.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 22caa58795b5e0f4787558f418793e8a
+folderAsset: yes
+timeCreated: 1489866328
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Editor/TestTickableManagerParenting.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Editor/TestTickableManagerParenting.cs
@@ -1,0 +1,148 @@
+﻿using ModestTree;
+using NUnit.Framework;
+using UnityEngine;
+using Zenject.Tests.TickableManagers.Parenting;
+using Assert = NUnit.Framework.Assert;
+
+namespace Zenject.Tests.TickableManagers
+{
+    [TestFixture]
+    public partial class TestTickableManagerParenting : ZenjectIntegrationTestFixture
+    {
+        GameObject NestedOnePrefab
+        {
+            get { return FixtureUtil.GetPrefab("TestParenting/NestedGameObjectContextOne"); }
+        }
+
+        GameObject NestedTwoPrefab
+        {
+            get { return FixtureUtil.GetPrefab("TestParenting/NestedGameObjectContextTwo"); }
+        }
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            RootTickable.TickCount = 0;
+            NestedTickableOne.TickCount = 0;
+            NestedTickableTwo.TickCount = 0;
+            DoublyNestedTickable.TickCount = 0;
+        }
+
+        [Test]
+        public void TestPausingRoot()
+        {
+            Container.BindInterfacesAndSelfTo<RootTickable>().AsSingle().NonLazy();
+
+            Container.Bind<NestedTickableOne>()
+                .FromSubContainerResolve()
+                .ByNewPrefab(NestedOnePrefab)
+                .AsSingle();
+
+            Container.Bind<NestedTickableTwo>()
+                .FromSubContainerResolve()
+                .ByNewPrefab(NestedTwoPrefab)
+                .AsSingle();
+
+            Initialize();
+
+            Container.Resolve<NestedTickableOne>();
+            Container.Resolve<NestedTickableTwo>();
+
+            var tickManager = Container.Resolve<TickableManager>();
+
+            // Contexts (GameObjectContext/SceneContext) use a MonoKernel to
+            // hook into the Unity Update. We need to simulate the Update loop.
+            var monoKernels = SceneContext.GetComponentsInChildren<MonoKernel>();
+
+            Assert.AreEqual(0, RootTickable.TickCount);
+            Assert.AreEqual(0, NestedTickableOne.TickCount);
+            Assert.AreEqual(0, NestedTickableTwo.TickCount);
+            Assert.AreEqual(0, DoublyNestedTickable.TickCount);
+
+            monoKernels.ForEach(kernel => kernel.Update());
+
+            Assert.AreEqual(1, RootTickable.TickCount);
+            Assert.AreEqual(1, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            tickManager.Pause();
+            monoKernels.ForEach(kernel => kernel.Update());
+
+            Assert.AreEqual(1, RootTickable.TickCount);
+            Assert.AreEqual(1, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            tickManager.Resume();
+            monoKernels.ForEach(kernel => kernel.Update());
+
+            Assert.AreEqual(2, RootTickable.TickCount);
+            Assert.AreEqual(2, NestedTickableOne.TickCount);
+            Assert.AreEqual(2, NestedTickableTwo.TickCount);
+            Assert.AreEqual(2, DoublyNestedTickable.TickCount);
+        }
+
+        [Test]
+        public void TestPausingNested()
+        {
+            Container.BindInterfacesAndSelfTo<RootTickable>().AsSingle().NonLazy();
+
+            Container.Bind<NestedTickableOne>()
+                .FromSubContainerResolve()
+                .ByNewPrefab(NestedOnePrefab)
+                .AsSingle();
+
+            Container.Bind<NestedTickableTwo>()
+                .FromSubContainerResolve()
+                .ByNewPrefab(NestedTwoPrefab)
+                .AsSingle();
+
+            Container.Bind<NestedTickableManagerHolder>()
+                .FromSubContainerResolve()
+                .ByNewPrefab(NestedTwoPrefab)
+                .AsSingle();
+
+            Initialize();
+
+            Container.Resolve<NestedTickableOne>();
+            Container.Resolve<NestedTickableTwo>();
+
+            var nestedTickManager = Container.Resolve<NestedTickableManagerHolder>().TickManager;
+
+            // Contexts (GameObjectContext/SceneContext) use a MonoKernel to
+            // hook into the Unity Update. We need to simulate the Update loop.
+            var monoKernels = SceneContext.GetComponentsInChildren<MonoKernel>();
+
+            Assert.AreEqual(0, RootTickable.TickCount);
+            Assert.AreEqual(0, NestedTickableOne.TickCount);
+            Assert.AreEqual(0, NestedTickableTwo.TickCount);
+            Assert.AreEqual(0, DoublyNestedTickable.TickCount);
+
+            monoKernels.ForEach(kernel => kernel.Update());
+
+            Assert.AreEqual(1, RootTickable.TickCount);
+            Assert.AreEqual(1, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            nestedTickManager.Pause();
+            monoKernels.ForEach(kernel => kernel.Update());
+
+            Assert.AreEqual(2, RootTickable.TickCount);
+            Assert.AreEqual(2, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            nestedTickManager.Resume();
+            monoKernels.ForEach(kernel => kernel.Update());
+
+            Assert.AreEqual(3, RootTickable.TickCount);
+            Assert.AreEqual(3, NestedTickableOne.TickCount);
+            Assert.AreEqual(2, NestedTickableTwo.TickCount);
+            Assert.AreEqual(2, DoublyNestedTickable.TickCount);
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Editor/TestTickableManagerParenting.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Editor/TestTickableManagerParenting.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: af3ce094715449844a8e68105759e2ff
+timeCreated: 1489867223
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c3e92d692627b2a44ad23203e2462987
+folderAsset: yes
+timeCreated: 1489866334
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 3c5ae8c1093da554d8bf77c912cc5433
+guid: c1b22709ca1fdfd43a098353d24d949d
 folderAsset: yes
-timeCreated: 1487820668
-licenseType: Pro
+timeCreated: 1489866399
+licenseType: Free
 DefaultImporter:
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/DoublyNestedGameObjectContext.prefab
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/DoublyNestedGameObjectContext.prefab
@@ -1,0 +1,70 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1010678771405022}
+  m_IsPrefabParent: 1
+--- !u!1 &1010678771405022
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4189121441744166}
+  - component: {fileID: 114844268813028026}
+  - component: {fileID: 114678707554150722}
+  m_Layer: 0
+  m_Name: DoublyNestedGameObjectContext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4189121441744166
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1010678771405022}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114678707554150722
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1010678771405022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d234235cf38842c68771124551b3fea3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114844268813028026
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1010678771405022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08eca9f7688a0a24685b89133b020c8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _installers:
+  - {fileID: 114678707554150722}
+  _installerPrefabs: []
+  _scriptableObjectInstallers: []
+  _kernel: {fileID: 0}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/DoublyNestedGameObjectContext.prefab.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/DoublyNestedGameObjectContext.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e4eee30d05aada469a9cdcea606c106
+timeCreated: 1489868398
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextOne.prefab
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextOne.prefab
@@ -1,0 +1,70 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1864905126651708}
+  m_IsPrefabParent: 1
+--- !u!1 &1864905126651708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4667138600986056}
+  - component: {fileID: 114563370882414088}
+  - component: {fileID: 114232595429747888}
+  m_Layer: 0
+  m_Name: NestedGameObjectContextOne
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4667138600986056
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1864905126651708}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114232595429747888
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1864905126651708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 877913d8b20d4bdea033bcd30cd5f329, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114563370882414088
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1864905126651708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08eca9f7688a0a24685b89133b020c8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _installers:
+  - {fileID: 114232595429747888}
+  _installerPrefabs: []
+  _scriptableObjectInstallers: []
+  _kernel: {fileID: 0}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextOne.prefab.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextOne.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: facba1ceee7cacf4c9a891e563469b44
+timeCreated: 1489868411
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextTwo.prefab
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextTwo.prefab
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1430265380958458}
+  m_IsPrefabParent: 1
+--- !u!1 &1430265380958458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4299636328569202}
+  - component: {fileID: 114033711862104504}
+  - component: {fileID: 114186337467076512}
+  m_Layer: 0
+  m_Name: NestedGameObjectContextTwo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4299636328569202
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1430265380958458}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114033711862104504
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1430265380958458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08eca9f7688a0a24685b89133b020c8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _installers:
+  - {fileID: 114186337467076512}
+  _installerPrefabs: []
+  _scriptableObjectInstallers: []
+  _kernel: {fileID: 0}
+--- !u!114 &114186337467076512
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1430265380958458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6069adecd5194437966aa32fa13c87c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DoublyNestedPrefab: {fileID: 1010678771405022, guid: 2e4eee30d05aada469a9cdcea606c106,
+    type: 2}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextTwo.prefab.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/Resources/TestParenting/NestedGameObjectContextTwo.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70d3c405e5dcdcf47a822b2d8de7c07d
+timeCreated: 1489868408
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b28c0d7ca040f1842926c128cd74b00f
+folderAsset: yes
+timeCreated: 1489866390
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickable.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickable.cs
@@ -1,0 +1,12 @@
+﻿namespace Zenject.Tests.TickableManagers.Parenting
+{
+    public class DoublyNestedTickable : ITickable
+    {
+        public static int TickCount = 0;
+
+        public void Tick()
+        {
+            TickCount++;
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickable.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 11ecbed431b54e9ebbfa5de82b5daf7a
+timeCreated: 1489867159

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickableInstaller.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickableInstaller.cs
@@ -1,0 +1,10 @@
+﻿namespace Zenject.Tests.TickableManagers.Parenting
+{
+    public class DoublyNestedTickableInstaller : MonoInstaller
+    {
+        public override void InstallBindings()
+        {
+            Container.BindInterfacesAndSelfTo<DoublyNestedTickable>().AsSingle().NonLazy();
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickableInstaller.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/DoublyNestedTickableInstaller.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d234235cf38842c68771124551b3fea3
+timeCreated: 1489867571

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableManagerHolder.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableManagerHolder.cs
@@ -1,0 +1,7 @@
+namespace Zenject.Tests.TickableManagers
+{
+        public class NestedTickableManagerHolder
+        {
+            [Inject] public TickableManager TickManager;
+        }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableManagerHolder.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableManagerHolder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1bdaf03dce8440da981ce4530d82bf06
+timeCreated: 1489876369

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOne.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOne.cs
@@ -1,0 +1,12 @@
+﻿namespace Zenject.Tests.TickableManagers.Parenting
+{
+    public class NestedTickableOne : ITickable
+    {
+        public static int TickCount = 0;
+
+        public void Tick()
+        {
+            TickCount++;
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOne.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOne.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c45bb3f4dd15fe841b1c88e77cc2633b
+timeCreated: 1489866543
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOneInstaller.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOneInstaller.cs
@@ -1,0 +1,10 @@
+﻿namespace Zenject.Tests.TickableManagers.Parenting
+{
+    public class NestedTickableOneInstaller : MonoInstaller
+    {
+        public override void InstallBindings()
+        {
+            Container.BindInterfacesAndSelfTo<NestedTickableOne>().AsSingle().NonLazy();
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOneInstaller.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableOneInstaller.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 877913d8b20d4bdea033bcd30cd5f329
+timeCreated: 1489867461

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwo.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwo.cs
@@ -1,0 +1,12 @@
+﻿namespace Zenject.Tests.TickableManagers.Parenting
+{
+    public class NestedTickableTwo : ITickable
+    {
+        public static int TickCount = 0;
+
+        public void Tick()
+        {
+            TickCount++;
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwo.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 948b2f8015d34a1a94a7da8101b37367
+timeCreated: 1489867144

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwoInstaller.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwoInstaller.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+
+namespace Zenject.Tests.TickableManagers.Parenting
+{
+    public class NestedTickableTwoInstaller : MonoInstaller
+    {
+        public GameObject DoublyNestedPrefab;
+
+        public override void InstallBindings()
+        {
+            Container.BindInterfacesAndSelfTo<NestedTickableTwo>().AsSingle().NonLazy();
+
+            Container.Bind<NestedTickableManagerHolder>().AsSingle();
+
+            Container.Bind<DoublyNestedTickable>()
+                .FromSubContainerResolve()
+                .ByNewPrefab(DoublyNestedPrefab)
+                .AsSingle()
+                .NonLazy();
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwoInstaller.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/NestedTickableTwoInstaller.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6069adecd5194437966aa32fa13c87c3
+timeCreated: 1489867541

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/RootTickable.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/RootTickable.cs
@@ -1,0 +1,12 @@
+﻿namespace Zenject.Tests.TickableManagers.Parenting
+{
+    public class RootTickable: ITickable
+    {
+        public static int TickCount = 0;
+
+        public void Tick()
+        {
+            TickCount++;
+        }
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/RootTickable.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/IntegrationTests/TickableManagers/TestParenting/RootTickable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: daf9aca8d75d4f8ea7110c46d458ffd9
+timeCreated: 1489872889

--- a/UnityProject/Assets/Zenject/OptionalExtras/UnitTests/Editor/Other/TestTickableManagerParenting.cs
+++ b/UnityProject/Assets/Zenject/OptionalExtras/UnitTests/Editor/Other/TestTickableManagerParenting.cs
@@ -1,0 +1,207 @@
+﻿using NUnit.Framework;
+
+namespace Zenject.Tests.Other
+{
+    [TestFixture]
+    public class TestTickableManagerParenting
+    {
+        [SetUp]
+        public void ResetCounts()
+        {
+            RootTickable.TickCount = 0;
+            NestedTickableOne.TickCount = 0;
+            NestedTickableTwo.TickCount = 0;
+            DoublyNestedTickable.TickCount = 0;
+        }
+
+        [Test]
+        public void TestPausingRoot()
+        {
+            var container = new DiContainer();
+
+            container.Bind(typeof(TickableManager), typeof(InitializableManager), typeof(DisposableManager))
+                .ToSelf().AsSingle().CopyIntoAllSubContainers();
+
+            container.Bind<ITickable>().To<RootTickable>().AsSingle();
+
+            // This is how you add ITickables / etc. within sub containers
+            container.BindInterfacesAndSelfTo<NestedKernel>()
+                .FromSubContainerResolve().ByMethod(InstallNestedOne).AsSingle();
+            container.BindInterfacesAndSelfTo<NestedKernel>()
+                .FromSubContainerResolve().ByMethod(InstallNestedTwo).AsSingle();
+
+            var tickManager = container.Resolve<TickableManager>();
+            var initManager = container.Resolve<InitializableManager>();
+            var disposeManager = container.Resolve<DisposableManager>();
+
+            Assert.AreEqual(0, RootTickable.TickCount);
+            Assert.AreEqual(0, NestedTickableOne.TickCount);
+            Assert.AreEqual(0, NestedTickableTwo.TickCount);
+            Assert.AreEqual(0, DoublyNestedTickable.TickCount);
+
+            initManager.Initialize();
+            tickManager.Update();
+            disposeManager.Dispose();
+
+            Assert.AreEqual(1, RootTickable.TickCount);
+            Assert.AreEqual(1, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            tickManager.Pause();
+            tickManager.Update();
+
+            Assert.AreEqual(1, RootTickable.TickCount);
+            Assert.AreEqual(1, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            tickManager.Resume();
+            tickManager.Update();
+
+            Assert.AreEqual(2, RootTickable.TickCount);
+            Assert.AreEqual(2, NestedTickableOne.TickCount);
+            Assert.AreEqual(2, NestedTickableTwo.TickCount);
+            Assert.AreEqual(2, DoublyNestedTickable.TickCount);
+        }
+
+        [Test]
+        public void TestPausingNested()
+        {
+            var container = new DiContainer();
+
+            container.Bind(typeof(TickableManager), typeof(InitializableManager), typeof(DisposableManager))
+                .ToSelf().AsSingle().CopyIntoAllSubContainers();
+
+            container.Bind<ITickable>().To<RootTickable>().AsSingle();
+
+            // This is how you add ITickables / etc. within sub containers
+            container.BindInterfacesAndSelfTo<NestedKernel>()
+                .FromSubContainerResolve().ByMethod(InstallNestedOne).AsSingle();
+            container.BindInterfacesAndSelfTo<NestedKernel>()
+                .FromSubContainerResolve().ByMethod(InstallNestedTwo).AsSingle();
+            container.Bind<NestedTickableManagerHolder>()
+                .FromSubContainerResolve().ByMethod(InstallNestedTwo).AsSingle();
+
+            var tickManager = container.Resolve<TickableManager>();
+            var initManager = container.Resolve<InitializableManager>();
+            var disposeManager = container.Resolve<DisposableManager>();
+
+            var nestedTickManager = container.Resolve<NestedTickableManagerHolder>();
+
+            Assert.AreEqual(0, RootTickable.TickCount);
+            Assert.AreEqual(0, NestedTickableOne.TickCount);
+            Assert.AreEqual(0, NestedTickableTwo.TickCount);
+            Assert.AreEqual(0, DoublyNestedTickable.TickCount);
+
+            initManager.Initialize();
+            tickManager.Update();
+            disposeManager.Dispose();
+
+            Assert.AreEqual(1, RootTickable.TickCount);
+            Assert.AreEqual(1, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            nestedTickManager.TickManager.Pause();
+            tickManager.Update();
+
+            Assert.AreEqual(2, RootTickable.TickCount);
+            Assert.AreEqual(2, NestedTickableOne.TickCount);
+            Assert.AreEqual(1, NestedTickableTwo.TickCount);
+            Assert.AreEqual(1, DoublyNestedTickable.TickCount);
+
+            nestedTickManager.TickManager.Resume();
+            tickManager.Update();
+
+            Assert.AreEqual(3, RootTickable.TickCount);
+            Assert.AreEqual(3, NestedTickableOne.TickCount);
+            Assert.AreEqual(2, NestedTickableTwo.TickCount);
+            Assert.AreEqual(2, DoublyNestedTickable.TickCount);
+        }
+
+        public void InstallNestedOne(DiContainer subContainer)
+        {
+            subContainer.Bind<NestedKernel>().AsSingle();
+
+            subContainer.Bind<NestedTickableManagerHolder>().AsSingle();
+
+            subContainer.Bind<ITickable>().To<NestedTickableOne>().AsSingle();
+        }
+
+        public void InstallNestedTwo(DiContainer subContainer)
+        {
+            subContainer.Bind<NestedKernel>().AsSingle();
+
+            subContainer.Bind<NestedTickableManagerHolder>().AsSingle();
+
+            subContainer.Bind<ITickable>().To<NestedTickableTwo>().AsSingle();
+
+            subContainer.BindInterfacesAndSelfTo<DoublyNestedKernel>()
+                .FromSubContainerResolve().ByMethod(InstallDoublyNested).AsSingle();
+        }
+
+        public void InstallDoublyNested(DiContainer subContainer)
+        {
+            subContainer.Bind<DoublyNestedKernel>().AsSingle();
+
+            subContainer.Bind<NestedTickableManagerHolder>().AsSingle();
+
+            subContainer.Bind<ITickable>().To<DoublyNestedTickable>().AsSingle();
+        }
+
+        public class NestedKernel : Kernel
+        {
+        }
+
+        public class DoublyNestedKernel : Kernel
+        {
+        }
+
+        public class NestedTickableManagerHolder
+        {
+            [Inject] public TickableManager TickManager;
+        }
+
+        public class RootTickable : ITickable
+        {
+            public static int TickCount = 0;
+
+            public void Tick()
+            {
+                TickCount++;
+            }
+        }
+
+        public class NestedTickableOne : ITickable
+        {
+            public static int TickCount = 0;
+
+            public void Tick()
+            {
+                TickCount++;
+            }
+        }
+
+        public class NestedTickableTwo : ITickable
+        {
+            public static int TickCount = 0;
+
+            public void Tick()
+            {
+                TickCount++;
+            }
+        }
+
+        public class DoublyNestedTickable : ITickable
+        {
+            public static int TickCount = 0;
+
+            public void Tick()
+            {
+                TickCount++;
+            }
+        }
+
+    }
+}

--- a/UnityProject/Assets/Zenject/OptionalExtras/UnitTests/Editor/Other/TestTickableManagerParenting.cs.meta
+++ b/UnityProject/Assets/Zenject/OptionalExtras/UnitTests/Editor/Other/TestTickableManagerParenting.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7e0be895588e428fa947f199581ae17e
+timeCreated: 1489861818

--- a/UnityProject/Assets/Zenject/Source/Editor/Testing/ZenjectIntegrationTestFixture.cs
+++ b/UnityProject/Assets/Zenject/Source/Editor/Testing/ZenjectIntegrationTestFixture.cs
@@ -27,6 +27,11 @@ namespace Zenject
             get { return _sceneContext.Container; }
         }
 
+        protected SceneContext SceneContext
+        {
+            get { return _sceneContext; }
+        }
+
         [SetUp]
         public virtual void SetUp()
         {

--- a/UnityProject/Assets/Zenject/Source/Runtime/TickableManager.cs
+++ b/UnityProject/Assets/Zenject/Source/Runtime/TickableManager.cs
@@ -7,6 +7,9 @@ namespace Zenject
 {
     public class TickableManager
     {
+        [Inject(Optional = true, Source = InjectSources.Parent)]
+        readonly TickableManager _parent = null;
+
         [Inject(Optional = true, Source = InjectSources.Local)]
         readonly List<ITickable> _tickables = null;
 
@@ -39,6 +42,11 @@ namespace Zenject
         public IEnumerable<ITickable> Tickables
         {
             get { return _tickables; }
+        }
+
+        public bool IsPaused
+        {
+            get { return _isPaused || (_parent != null ? _parent.IsPaused : _isPaused); }
         }
 
         [Inject]
@@ -153,7 +161,7 @@ namespace Zenject
 
         public void Update()
         {
-            if(_isPaused)
+            if(IsPaused)
             {
                 return;
             }
@@ -164,7 +172,7 @@ namespace Zenject
 
         public void FixedUpdate()
         {
-            if(_isPaused)
+            if(IsPaused)
             {
                 return;
             }
@@ -175,7 +183,7 @@ namespace Zenject
 
         public void LateUpdate()
         {
-            if(_isPaused)
+            if(IsPaused)
             {
                 return;
             }


### PR DESCRIPTION
Adds a parent `TickableManager` to each subcontainer `TickableManager`, creating a hierarchy of tickable managers. 

When a tickable manager checks the pause state, it checks it's own pause state as well as the parent tickable manager. This means that pausing a parent tickable manager will pause all child tickable managers. Pausing the root tickable manager will pause all tickable managers.