### PR TITLE
Better Resharper integration, minor FromComponentIn* improvements, injecting IEnumerator methods

### DIFF
--- a/UnityProject/Assets/Zenject/Source/Binding/Binders/FromBinders/FromBinderGeneric.cs
+++ b/UnityProject/Assets/Zenject/Source/Binding/Binders/FromBinders/FromBinderGeneric.cs
@@ -57,35 +57,43 @@ namespace Zenject
 
 #if !NOT_UNITY3D
 
-        public ScopeArgConditionCopyNonLazyBinder FromComponentInChildren()
-        {
-            BindingUtil.AssertIsInterfaceOrComponent(AllParentTypes);
+		public ScopeArgConditionCopyNonLazyBinder FromComponentInChildren(bool excludeSelf = false)
+		{
+			BindingUtil.AssertIsInterfaceOrComponent(AllParentTypes);
 
-            return FromMethodMultiple((ctx) =>
-                {
-                    Assert.That(ctx.ObjectType.DerivesFromOrEqual<MonoBehaviour>());
-                    Assert.IsNotNull(ctx.ObjectInstance);
+			return FromMethodMultiple((ctx) =>
+				{
+					Assert.That(ctx.ObjectType.DerivesFromOrEqual<MonoBehaviour>());
+					Assert.IsNotNull(ctx.ObjectInstance);
 
-                    return ((MonoBehaviour)ctx.ObjectInstance).GetComponentsInChildren<TContract>()
-                        .Where(x => !ReferenceEquals(x, ctx.ObjectInstance));
-                });
-        }
+					var res = ((MonoBehaviour)ctx.ObjectInstance).GetComponentsInChildren<TContract>()
+																 .Where(x => !ReferenceEquals(x, ctx.ObjectInstance));
 
-        public ScopeArgConditionCopyNonLazyBinder FromComponentInParents()
-        {
-            BindingUtil.AssertIsInterfaceOrComponent(AllParentTypes);
+					if (excludeSelf) res = res.Where(x => (x as Component).gameObject != (ctx.ObjectInstance as Component).gameObject);
 
-            return FromMethodMultiple((ctx) =>
-                {
-                    Assert.That(ctx.ObjectType.DerivesFromOrEqual<MonoBehaviour>());
-                    Assert.IsNotNull(ctx.ObjectInstance);
+					return res;
+				});
+		}
 
-                    return ((MonoBehaviour)ctx.ObjectInstance).GetComponentsInParent<TContract>()
-                        .Where(x => !ReferenceEquals(x, ctx.ObjectInstance));
-                });
-        }
+		public ScopeArgConditionCopyNonLazyBinder FromComponentInParents(bool excludeSelf = false)
+		{
+			BindingUtil.AssertIsInterfaceOrComponent(AllParentTypes);
 
-        public ScopeArgConditionCopyNonLazyBinder FromComponentSibling()
+			return FromMethodMultiple((ctx) =>
+				{
+					Assert.That(ctx.ObjectType.DerivesFromOrEqual<MonoBehaviour>());
+					Assert.IsNotNull(ctx.ObjectInstance);
+
+					var res = ((MonoBehaviour)ctx.ObjectInstance).GetComponentsInParent<TContract>()
+						.Where(x => !ReferenceEquals(x, ctx.ObjectInstance));
+
+					if (excludeSelf) res = res.Where(x => (x as Component).gameObject != (ctx.ObjectInstance as Component).gameObject);
+
+					return res;
+				});
+		}
+
+		public ScopeArgConditionCopyNonLazyBinder FromComponentSibling()
         {
             BindingUtil.AssertIsInterfaceOrComponent(AllParentTypes);
 

--- a/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Zenject/Source/Main/DiContainer.cs
@@ -973,7 +973,20 @@ namespace Zenject
 
                     if (!isDryRun)
                     {
-                        method.MethodInfo.Invoke(injectable, paramValues.ToArray());
+						//Handle IEnumerators (Coroutines) as a special case by calling StartCoroutine() instead of invoking directly.
+	                    if (method.MethodInfo.ReturnType == typeof(IEnumerator)) {
+							var injectableAsMonoBehaviour = injectable as MonoBehaviour;
+
+		                    if (injectableAsMonoBehaviour == null)
+			                    throw Assert.CreateException(
+			                                                 "Can't inject IEnumerator method '{0}' on '{1}'. '{1}' is not a MonoBehaviour.",
+															 method.MethodInfo.Name, method.MethodInfo.DeclaringType);
+
+							var result = method.MethodInfo.Invoke(injectable, paramValues.ToArray()) as IEnumerator;
+		                    injectableAsMonoBehaviour.StartCoroutine(result);
+	                    } else {
+		                    method.MethodInfo.Invoke(injectable, paramValues.ToArray());
+	                    }
                     }
                 }
             }

--- a/UnityProject/Assets/Zenject/Source/Usage/InjectAttribute.cs
+++ b/UnityProject/Assets/Zenject/Source/Usage/InjectAttribute.cs
@@ -1,10 +1,12 @@
 using System;
+using JetBrains.Annotations;
 
 namespace Zenject
 {
     [AttributeUsage(AttributeTargets.Constructor
         | AttributeTargets.Method | AttributeTargets.Parameter
         | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+	[MeansImplicitUse]
     public class InjectAttribute : InjectAttributeBase
     {
     }


### PR DESCRIPTION
- Added an option to exclude self (current object) in FromComponentInChildren and FromComponentInParents. This is useful if a component is present on both current object and its child/parent.

- Marked the [Inject] attribute with MeansImplicitUseAttribute to improve integration with JetBrains Resharper - it is no longer needed to mark all injected properties with [UsedImplicitly]