### PR TITLE
Add support for late install in DecoratorContexts

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Editor/Editors/SceneDecoratorContextEditor.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Editor/Editors/SceneDecoratorContextEditor.cs
@@ -15,6 +15,48 @@ namespace Zenject
     {
         SerializedProperty _decoratedContractNameProperty;
 
+        protected override string[] PropertyNames
+        {
+            get
+            {
+                return base.PropertyNames.Concat(new string[]
+                    {
+                        "_lateInstallers",
+                        "_lateInstallerPrefabs",
+                        "_lateScriptableObjectInstallers"
+                    })
+                    .ToArray();
+            }
+        }
+
+        protected override string[] PropertyDisplayNames
+        {
+            get
+            {
+                return base.PropertyDisplayNames.Concat(new string[]
+                    {
+                        "Late Installers",
+                        "Late Prefab Installers",
+                        "Late Scriptable Object Installers"
+                    })
+                    .ToArray();
+            }
+        }
+
+        protected override string[] PropertyDescriptions
+        {
+            get
+            {
+                return base.PropertyDescriptions.Concat(new string[]
+                    {
+                        "Drag any MonoInstallers that you have added to your Scene Hierarchy here. They'll be installed after the target installs its bindings",
+                        "Drag any prefabs that contain a MonoInstaller on them here. They'll be installed after the target installs its bindings",
+                        "Drag any assets in your Project that implement ScriptableObjectInstaller here. They'll be installed after the target installs its bindings"
+                    })
+                    .ToArray();
+            }
+        }
+
         public override void OnEnable()
         {
             base.OnEnable();

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
@@ -73,17 +73,17 @@ namespace Zenject
         {
             get;
         }
+        public abstract IEnumerable<GameObject> GetRootGameObjects();
+
 
         public void AddNormalInstaller(InstallerBase installer)
         {
             _normalInstallers.Add(installer);
         }
 
-        public abstract IEnumerable<GameObject> GetRootGameObjects();
-
-        void CheckInstallerPrefabTypes()
+        void CheckInstallerPrefabTypes(List<MonoInstaller> installers, List<MonoInstaller> installerPrefabs)
         {
-            foreach (var installer in _installers)
+            foreach (var installer in installers)
             {
                 Assert.IsNotNull(installer, "Found null installer in Context '{0}'", this.name);
 
@@ -93,7 +93,7 @@ namespace Zenject
 #endif
             }
 
-            foreach (var installerPrefab in _installerPrefabs)
+            foreach (var installerPrefab in installerPrefabs)
             {
                 Assert.IsNotNull(installerPrefab, "Found null prefab in Context");
 
@@ -109,7 +109,16 @@ namespace Zenject
 
         protected void InstallInstallers()
         {
-            CheckInstallerPrefabTypes();
+            InstallInstallers(_normalInstallers, _scriptableObjectInstallers, _installers, _installerPrefabs);
+        }
+
+        protected void InstallInstallers(
+            List<InstallerBase> normalInstallers,
+            List<ScriptableObjectInstaller> scriptableObjectInstallers,
+            List<MonoInstaller> installers,
+            List<MonoInstaller> installerPrefabs)
+        {
+            CheckInstallerPrefabTypes(installers, installerPrefabs);
 
             // Ideally we would just have one flat list of all the installers
             // since that way the user has complete control over the order, but
@@ -129,10 +138,10 @@ namespace Zenject
             // ScriptableObjectInstallers are often used for settings (including settings
             // that are injected into other installers like MonoInstallers)
 
-            var allInstallers = _normalInstallers.Cast<IInstaller>()
-                .Concat(_scriptableObjectInstallers.Cast<IInstaller>()).Concat(_installers.Cast<IInstaller>()).ToList();
+            var allInstallers = normalInstallers.Cast<IInstaller>()
+                .Concat(scriptableObjectInstallers.Cast<IInstaller>()).Concat(installers.Cast<IInstaller>()).ToList();
 
-            foreach (var installerPrefab in _installerPrefabs)
+            foreach (var installerPrefab in installerPrefabs)
             {
                 Assert.IsNotNull(installerPrefab, "Found null installer prefab in '{0}'", this.GetType());
 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs
@@ -287,6 +287,11 @@ namespace Zenject
             }
 
             InstallInstallers();
+
+            foreach (var decoratorContext in _decoratorContexts)
+            {
+                decoratorContext.InstallLateDecoratorInstallers();
+            }
         }
 
         protected override IEnumerable<MonoBehaviour> GetInjectableMonoBehaviours()

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/SceneDecoratorContext.cs
@@ -12,6 +12,54 @@ namespace Zenject
 {
     public class SceneDecoratorContext : Context
     {
+        [SerializeField]
+        List<MonoInstaller> _lateInstallers = new List<MonoInstaller>();
+
+        [SerializeField]
+        List<MonoInstaller> _lateInstallerPrefabs = new List<MonoInstaller>();
+
+        [SerializeField]
+        List<ScriptableObjectInstaller> _lateScriptableObjectInstallers = new List<ScriptableObjectInstaller>();
+
+        public IEnumerable<MonoInstaller> LateInstallers
+        {
+            get
+            {
+                return _lateInstallers;
+            }
+            set
+            {
+                _lateInstallers.Clear();
+                _lateInstallers.AddRange(value);
+            }
+        }
+
+        public IEnumerable<MonoInstaller> LateInstallerPrefabs
+        {
+            get
+            {
+                return _lateInstallerPrefabs;
+            }
+            set
+            {
+                _lateInstallerPrefabs.Clear();
+                _lateInstallerPrefabs.AddRange(value);
+            }
+        }
+
+        public IEnumerable<ScriptableObjectInstaller> LateScriptableObjectInstallers
+        {
+            get
+            {
+                return _lateScriptableObjectInstallers;
+            }
+            set
+            {
+                _lateScriptableObjectInstallers.Clear();
+                _lateScriptableObjectInstallers.AddRange(value);
+            }
+        }
+
         [FormerlySerializedAs("SceneName")]
         [SerializeField]
         string _decoratedContractName = null;
@@ -64,6 +112,11 @@ namespace Zenject
         protected override IEnumerable<MonoBehaviour> GetInjectableMonoBehaviours()
         {
             return ZenUtilInternal.GetInjectableMonoBehaviours(this.gameObject.scene);
+        }
+
+        public void InstallLateDecoratorInstallers()
+        {
+            InstallInstallers(new List<InstallerBase>(), _lateScriptableObjectInstallers, _lateInstallers, _lateInstallerPrefabs);
         }
     }
 }


### PR DESCRIPTION
Allows `DecoratorContexts` to install bindings after the target has finished installing, to support cases where the user might want to override some bindings in the target context. 

Adds the following fields to `DecoratorContext`:
- `Late Installers`
- `Late Prefab Installers`
- `Late Scriptable Object Installers`
