### PR TITLE
Added support for: readonly properties, search predicates, and including inactive objects.

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Usage/InjectOptionalAttribute.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Usage/InjectOptionalAttribute.cs
@@ -1,9 +1,11 @@
 using System;
+using JetBrains.Annotations;
 
 namespace Zenject
 {
     [AttributeUsage(AttributeTargets.Parameter
         | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+	[MeansImplicitUse]
     public class InjectOptionalAttribute : InjectAttributeBase
     {
         public InjectOptionalAttribute()


### PR DESCRIPTION
- Added a search predicate to FromComponentInChildren and to FromComponentInHierarchy.
- Added an option to include inactive objects to FromComponentInChildren and FromComponentInHierarchy.
- Added support for injecting C# 6.0 get-only (readonly properties).