### PR TITLE
Binding factory to contract

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
@@ -2000,6 +2000,13 @@ namespace Zenject
             return BindFactoryInternal<TContract, TFactory, TFactory>();
         }
 
+        public FactoryToChoiceIdBinder<TContract> BindFactoryContract<TContract, TFactoryContract, TFactoryConcrete>()
+            where TFactoryConcrete : Factory<TContract>, TFactoryContract
+            where TFactoryContract : IFactory
+        {
+            return BindFactoryInternal<TContract, TFactoryContract, TFactoryConcrete>();
+        }
+
         public MemoryPoolInitialSizeBinder<TItemContract> BindMemoryPool<TItemContract>()
         {
             return BindMemoryPool<TItemContract, MemoryPool<TItemContract>>();
@@ -2059,6 +2066,13 @@ namespace Zenject
                 TParam1, TContract, TFactory, TFactory>();
         }
 
+        public FactoryToChoiceIdBinder<TParam1, TContract> BindFactoryContract<TParam1, TContract, TFactoryContract, TFactoryConcrete>()
+            where TFactoryConcrete : Factory<TParam1, TContract>, TFactoryContract
+            where TFactoryContract : IFactory
+        {
+            return BindFactoryInternal<TParam1, TContract, TFactoryContract, TFactoryConcrete>();
+        }
+
         FactoryToChoiceIdBinder<TParam1, TParam2, TContract> BindFactoryInternal<TParam1, TParam2, TContract, TFactoryContract, TFactoryConcrete>()
             where TFactoryConcrete : TFactoryContract, IFactory
             where TFactoryContract : IFactory
@@ -2084,6 +2098,13 @@ namespace Zenject
         {
             return BindFactoryInternal<
                 TParam1, TParam2, TContract, TFactory, TFactory>();
+        }
+
+        public FactoryToChoiceIdBinder<TParam1, TParam2, TContract> BindFactoryContract<TParam1, TParam2, TContract, TFactoryContract, TFactoryConcrete>()
+            where TFactoryConcrete : Factory<TParam1, TParam2, TContract>, TFactoryContract
+            where TFactoryContract : IFactory
+        {
+            return BindFactoryInternal<TParam1, TParam2, TContract, TFactoryContract, TFactoryConcrete>();
         }
 
         FactoryToChoiceIdBinder<TParam1, TParam2, TParam3, TContract> BindFactoryInternal<TParam1, TParam2, TParam3, TContract, TFactoryContract, TFactoryConcrete>()
@@ -2113,6 +2134,13 @@ namespace Zenject
                 TParam1, TParam2, TParam3, TContract, TFactory, TFactory>();
         }
 
+        public FactoryToChoiceIdBinder<TParam1, TParam2, TParam3, TContract> BindFactoryContract<TParam1, TParam2, TParam3, TContract, TFactoryContract, TFactoryConcrete>()
+            where TFactoryConcrete : Factory<TParam1, TParam2, TParam3, TContract>, TFactoryContract
+            where TFactoryContract : IFactory
+        {
+            return BindFactoryInternal<TParam1, TParam2, TParam3, TContract, TFactoryContract, TFactoryConcrete>();
+        }
+
         FactoryToChoiceIdBinder<TParam1, TParam2, TParam3, TParam4, TContract> BindFactoryInternal<TParam1, TParam2, TParam3, TParam4, TContract, TFactoryContract, TFactoryConcrete>()
             where TFactoryConcrete : TFactoryContract, IFactory
             where TFactoryContract : IFactory
@@ -2140,6 +2168,13 @@ namespace Zenject
                 TParam1, TParam2, TParam3, TParam4, TContract, TFactory, TFactory>();
         }
 
+        public FactoryToChoiceIdBinder<TParam1, TParam2, TParam3, TParam4, TContract> BindFactoryContract<TParam1, TParam2, TParam3, TParam4, TContract, TFactoryContract, TFactoryConcrete>()
+            where TFactoryConcrete : Factory<TParam1, TParam2, TParam3, TParam4, TContract>, TFactoryContract
+            where TFactoryContract : IFactory
+        {
+            return BindFactoryInternal<TParam1, TParam2, TParam3, TParam4, TContract, TFactoryContract, TFactoryConcrete>();
+        }
+
         FactoryToChoiceIdBinder<TParam1, TParam2, TParam3, TParam4, TParam5, TContract> BindFactoryInternal<TParam1, TParam2, TParam3, TParam4, TParam5, TContract, TFactoryContract, TFactoryConcrete>()
             where TFactoryConcrete : TFactoryContract, IFactory
             where TFactoryContract : IFactory
@@ -2165,6 +2200,13 @@ namespace Zenject
         {
             return BindFactoryInternal<
                 TParam1, TParam2, TParam3, TParam4, TParam5, TContract, TFactory, TFactory>();
+        }
+
+        public FactoryToChoiceIdBinder<TParam1, TParam2, TParam3, TParam4, TParam5, TContract> BindFactoryContract<TParam1, TParam2, TParam3, TParam4, TParam5, TContract, TFactoryContract, TFactoryConcrete>()
+            where TFactoryConcrete : Factory<TParam1, TParam2, TParam3, TParam4, TParam5, TContract>, TFactoryContract
+            where TFactoryContract : IFactory
+        {
+            return BindFactoryInternal<TParam1, TParam2, TParam3, TParam4, TParam5, TContract, TFactoryContract, TFactoryConcrete>();
         }
 
         public T InstantiateExplicit<T>(List<TypeValuePair> extraArgs)


### PR DESCRIPTION
I ran into a situation where I needed to pair a factory with the type of object it was created with. I had thought I had found a solution, but discovered that you are currently unable to bind factories to contract like normal types. Looking into the `DiContainer` I noticed this would be a simple implementation, so I decided to make a pull request.

Below is a simplified example of how I intend to use such a feature...

```csharp
public abstract class Foo
{

}

public interface IFooFactory : IFactory<Foo>
{
    Type FooType { get; }
}

public sealed class FooFactory<TFoo> : Factory<TFoo>, IFooFactory
    where TFoo : Foo
{
    public Type FooType { get { return typeof(TFoo); } }

    public new TFoo Create()
    {
        base.Create();
    }

    // Explicit implementation of `IFactory<Foo>` from `IFooFactory`
    Foo IFactory<Foo>.Create()
    {
        Create();
    }
}

public class FooManager
{
    private Dictionary<Type, IFooFactory> fooFactories;

    [Inject]
    public FooManager(List<IFooFactory> fooFactoryList)
    {
        fooFactories = new Dictionary<Type, IFooFactory>(fooFactoryList.Count);
        foreach (var fooFactory in fooFactoryList)
        {
            fooFactories[fooFactory.FooType] = fooFactory;
        }
    }

    // Methods to create `Foo` types
}

public abstract class FooInstallerBase : MonoInstaller
{
    protected abstract void BindFooFactory<TFoo>()
        where TFoo : Foo
    {
        Container.BindFactoryContract<Foo, IFooFactory, FooFactory<TFoo>>()
            .WhenInjectedInto<FooManager>();
    }
}
```

Basically the idea behind my example is to selectively bind types of `Foo` into factories based on what installers that extend `FooInstallerBase` get installed. Then I can dynamically inject them all as non generic interfaces in list form to be processed into a `Dictionary<Type, IFooFactory>` for management by the `FooManager`.