### PR TITLE
Get-only properties fix; disabling install warning.

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
@@ -48,7 +48,10 @@ namespace Zenject
         bool _isInstalling;
         bool _hasDisplayedInstallWarning;
 
-        public DiContainer(bool isValidating)
+	    public bool ShouldCheckForInstallWarning = true;
+
+
+		public DiContainer(bool isValidating)
         {
             _isValidating = isValidating;
 
@@ -470,8 +473,9 @@ namespace Zenject
             return ReflectionUtil.CreateGenericList(context.MemberType, new object[] {});
         }
 
-        void CheckForInstallWarning(InjectContext context)
-        {
+        void CheckForInstallWarning(InjectContext context) {
+	        if (!ShouldCheckForInstallWarning) return;
+
             Assert.IsNotNull(context);
 #if DEBUG || UNITY_EDITOR
             if (!_isInstalling)


### PR DESCRIPTION
1. A fix to get-only properties when both parent and child classes implement the same injectable private property. We want to make sure to inject all of the properties in the hierarchy.

2. Added an option to disable install warning. Sometimes it is useful to resolve the current context from outside of the main installer.
