### PR TITLE
Removed orphan .meta file that is an issue in Unity

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Asteroids.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Asteroids.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 0e2a7784f7869d34f9b5e44b29a81384
-folderAsset: yes
-timeCreated: 1477227197
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
If you want to use Zenject as a readonly submodule pointing to the master repo, everytime you open Unity it will delete this file.
So you will have pending changes and it'll make it annoying when you want to pull changes