### PR TITLE
Prevent prefabs from being marked as 'modified' in certain version control systems (e.g. PlasticSCM) whenever Zenject instantiates them

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
@@ -79,7 +79,7 @@ namespace Zenject
 
             var prefab = TryGetPrefab();
 
-            bool shouldMakeActive = false;
+            var prefabWasActive = false;
 
             if (prefab == null)
             {
@@ -88,27 +88,45 @@ namespace Zenject
             }
             else
             {
-                var wasActive = prefab.activeSelf;
+                prefabWasActive = prefab.activeSelf;
 
-                shouldMakeActive = wasActive;
+                GameObject gameObjectInstance;
+#if UNITY_EDITOR
+                if(prefabWasActive)
+                {
+                    // This ensures the prefab's Awake() methods don't fire (and, if in the editor, that the prefab file doesn't get modified)
+                    gameObjectInstance = GameObject.Instantiate(prefab, ZenUtilInternal.GetOrCreateInactivePrefabParent());
+                    gameObjectInstance.SetActive(false);
+                    gameObjectInstance.transform.SetParent(null, false);
+                }
+                else
+                {
+                    gameObjectInstance = GameObject.Instantiate(prefab);
+                }
+#else
+                if(prefabWasActive)
+                {
+                    prefab.SetActive(false);
+                    gameObjectInstance = GameObject.Instantiate(prefab);
+                    prefab.SetActive(true);
+                }
+                else
+                {
+                    gameObjectInstance = GameObject.Instantiate(prefab);
+                }
+#endif
 
-                _instance = GameObject.Instantiate(prefab, DiContainer.DisabledIndestructiblePrefabParent).GetComponent<ProjectContext>();
+                _instance = gameObjectInstance.GetComponent<ProjectContext>();
 
                 Assert.IsNotNull(_instance,
                     "Could not find ProjectContext component on prefab 'Resources/{0}.prefab'", ProjectContextResourcePath);
-
-                if(wasActive) {
-                    _instance.gameObject.SetActive(false);
-                }
-                
-                _instance.transform.SetParent(null, false);
             }
 
             // Note: We use Initialize instead of awake here in case someone calls
             // ProjectContext.Instance while ProjectContext is initializing
             _instance.Initialize();
 
-            if (shouldMakeActive)
+            if (prefabWasActive)
             {
                 // We always instantiate it as disabled so that Awake and Start events are triggered after inject
                 _instance.gameObject.SetActive(true);

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/ProjectContext.cs
@@ -92,27 +92,16 @@ namespace Zenject
 
                 shouldMakeActive = wasActive;
 
-                if (wasActive)
-                {
-                    prefab.SetActive(false);
-                }
-
-                try
-                {
-                    _instance = GameObject.Instantiate(prefab).GetComponent<ProjectContext>();
-                }
-                finally
-                {
-                    if (wasActive)
-                    {
-                        // Always make sure to reset prefab state otherwise this change could be saved
-                        // persistently
-                        prefab.SetActive(true);
-                    }
-                }
+                _instance = GameObject.Instantiate(prefab, DiContainer.DisabledIndestructiblePrefabParent).GetComponent<ProjectContext>();
 
                 Assert.IsNotNull(_instance,
                     "Could not find ProjectContext component on prefab 'Resources/{0}.prefab'", ProjectContextResourcePath);
+
+                if(wasActive) {
+                    _instance.gameObject.SetActive(false);
+                }
+                
+                _instance.transform.SetParent(null, false);
             }
 
             // Note: We use Initialize instead of awake here in case someone calls

--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenUtilInternal.cs
@@ -186,6 +186,30 @@ namespace Zenject.Internal
                     && x.GetComponent<ProjectContext>() == null
                     && x.scene == scene);
         }
+
+        // Returns a Transform in the DontDestroyOnLoad scene (or, if we're not in play mode, within the current active scene)
+        // whose GameObject is inactive, and whose hide flags are set to HideAndDontSave. We can instantiate prefabs in here
+        // without any of their Awake() methods firing.
+        public static Transform GetOrCreateInactivePrefabParent()
+        {
+            if(disabledIndestructibleGameObject == null || (!Application.isPlaying && disabledIndestructibleGameObject.scene != SceneManager.GetActiveScene()))
+            {
+                var go = new GameObject("ZenUtilInternal_PrefabParent");
+                go.hideFlags = HideFlags.HideAndDontSave;
+                go.SetActive(false);
+
+                if(Application.isPlaying)
+                {
+                    UnityEngine.Object.DontDestroyOnLoad(go);
+                }
+
+                disabledIndestructibleGameObject = go;
+            }
+
+            return disabledIndestructibleGameObject.transform;
+        }
+
+        static GameObject disabledIndestructibleGameObject;
 #endif
     }
 }


### PR DESCRIPTION
An effort to resolve #259 by introducing special prefab instantiation logic while running in the editor. Essentially we create an inactive and hidden GameObject into which we first instantiate any prefab (thus avoiding the firing of its Awake methods), then re-parent said prefab into its desired location.