### PR TITLE
Add new ExpandPoolBy method to MemoryPoolBase

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Factories/Bindings/TestMemoryPool0.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Factories/Bindings/TestMemoryPool0.cs
@@ -190,6 +190,66 @@ namespace Zenject.Tests.Bindings
             Assert.IsEqual(factory.NumInactive, 5);
         }
 
+        [Test]
+        public void TestExpandManually()
+        {
+            Container.BindMemoryPool<Foo, Foo.Pool>();
+
+            var factory = Container.Resolve<Foo.Pool>();
+
+            Assert.IsEqual(factory.NumActive, 0);
+            Assert.IsEqual(factory.NumTotal, 0);
+            Assert.IsEqual(factory.NumInactive, 0);
+
+            factory.ExpandPoolBy(2);
+
+            Assert.IsEqual(factory.NumActive, 0);
+            Assert.IsEqual(factory.NumTotal, 2);
+            Assert.IsEqual(factory.NumInactive, 2);
+
+            var foo = factory.Spawn();
+
+            Assert.IsEqual(factory.NumActive, 1);
+            Assert.IsEqual(factory.NumTotal, 2);
+            Assert.IsEqual(factory.NumInactive, 1);
+
+            factory.ExpandPoolBy(3);
+
+            Assert.IsEqual(factory.NumActive, 1);
+            Assert.IsEqual(factory.NumTotal, 5);
+            Assert.IsEqual(factory.NumInactive, 4);
+
+            var foo2 = factory.Spawn();
+
+            Assert.IsEqual(factory.NumActive, 2);
+            Assert.IsEqual(factory.NumTotal, 5);
+            Assert.IsEqual(factory.NumInactive, 3);
+
+            var foo3 = factory.Spawn();
+
+            Assert.IsEqual(factory.NumActive, 3);
+            Assert.IsEqual(factory.NumTotal, 5);
+            Assert.IsEqual(factory.NumInactive, 2);
+
+            factory.ExpandPoolBy(1);
+
+            Assert.IsEqual(factory.NumActive, 3);
+            Assert.IsEqual(factory.NumTotal, 6);
+            Assert.IsEqual(factory.NumInactive, 3);
+
+            factory.Despawn(foo2);
+
+            Assert.IsEqual(factory.NumActive, 2);
+            Assert.IsEqual(factory.NumTotal, 6);
+            Assert.IsEqual(factory.NumInactive, 4);
+
+            var foo4 = factory.Spawn();
+
+            Assert.IsEqual(factory.NumActive, 3);
+            Assert.IsEqual(factory.NumTotal, 6);
+            Assert.IsEqual(factory.NumInactive, 3);
+        }
+
         class Bar
         {
             public Bar()

--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/MemoryPoolBase.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/MemoryPoolBase.cs
@@ -140,6 +140,29 @@ namespace Zenject
             return item;
         }
 
+        /// <summary>
+        /// Expands the pool by the additional size.
+        ///
+        /// This bypasses the configured expansion method (OneAtATime or Doubling), but still enforces the Fixed size
+        /// constraint.
+        /// </summary>
+        /// <param name="additionalSize">The additional number of items to allocate in the pool.</param>
+        /// <exception cref="PoolExceededFixedSizeException">if the pool is configured with a fixed size.</exception>
+        public void ExpandPoolBy(int additionalSize)
+        {
+            if (_settings.ExpandMethod == PoolExpandMethods.Fixed)
+            {
+                throw new PoolExceededFixedSizeException(
+                    "Pool factory '{0}' exceeded its max size of '{1}'!"
+                    .Fmt(this.GetType(), NumTotal));
+            }
+
+            for (int i = 0; i < additionalSize; i++)
+            {
+                _inactiveItems.Push(AllocNew());
+            }
+        }
+
         void ExpandPool()
         {
             switch (_settings.ExpandMethod)


### PR DESCRIPTION
The ExpandPoolBy method allows programmatic increases in the
memory pool size. This allows finer grained control of when
the memory pool expands, such as part of a loading screen
or in the background over the course of several update cycles.