### PR TITLE
Prevent test runner object from being deleted in Unity 2018. Resolves #420

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ZenjectIntegrationTest/ZenjectIntegrationTestFixture.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ZenjectIntegrationTest/ZenjectIntegrationTestFixture.cs
@@ -49,11 +49,25 @@ namespace Zenject
         public void Setup()
         {
             // Only need to record this once for each set of tests
+            #if UNITY_2018_1_OR_NEWER
+            // Unity 2018 flags the test runner object as DontDestroyOnLoad.
+            // This is a workaround to prevent it from being deleted during cleanup.
+            if (_unityTestRunnerObjects == null)
+            {
+                GameObject go = new GameObject();
+                GameObject.DontDestroyOnLoad(go);
+
+                Scene dontDestroyOnLoadScene = go.scene;
+                GameObject.DestroyImmediate(go);
+                _unityTestRunnerObjects = dontDestroyOnLoadScene.GetRootGameObjects().ToList();
+            }
+            #else
             if (_unityTestRunnerObjects == null)
             {
                 _unityTestRunnerObjects = SceneManager.GetActiveScene()
                     .GetRootGameObjects().ToList();
             }
+            #endif
         }
 
         protected void SkipInstall()


### PR DESCRIPTION
Unity 2018 has changed the scene behaviour of the test runner object. It is now flagged as DontDestroyOnLoad, which breaks the cleanup code that checks the active scene for the test runner object.

This is a crude fix that temporarily adds an object to DontDestroyOnLoad so that all other test runner objects can be added to the test runner objects list.