### PR TITLE
Release null objects from MemoryPoolBase

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/MemoryPoolBase.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/MemoryPoolBase.cs
@@ -125,14 +125,21 @@ namespace Zenject
         protected TContract GetInternal()
         {
             TContract item;
-
             if (_inactiveItems.Count == 0)
             {
                 ExpandPool();
                 Assert.That(!_inactiveItems.IsEmpty());
             }
 
-            item = _inactiveItems.Pop();
+            do
+            {
+                item = _inactiveItems.Pop();
+                if (item != null || _inactiveItems.Count != 0)
+                    continue;
+                ExpandPool();
+                Assert.That(!_inactiveItems.IsEmpty());
+            }
+            while (item == null);
 
             _activeCount++;
 


### PR DESCRIPTION
In Unity MemoryPool entries can become null through calls to Object.Destroy(entry).

When the MemoryPool returns a value, which has been destroyed, this will cause problems. This is in particular problematic for MonoMemoryPool which can hold references to objects in a scene which is unloaded. I've added a minor addition to MemoryPoolBase which will release items which are null. It now pops items until it finds one which is not null and expands the pool whenever the last item had been popped (e.g. all items are destroyed because they belonged to an unloaded scene)