### PR TITLE
Added method to shrink a MemoryPool down to a maximum of n inactiveItems

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/MemoryPoolBase.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Factories/Pooling/MemoryPoolBase.cs
@@ -121,6 +121,17 @@ namespace Zenject
                     "Validation for factory '{0}' failed".Fmt(this.GetType()), e);
             }
         }
+        
+        /// <summary>
+        /// Shrinks the MemoryPool down to a maximum of maxInactive inactive items
+        /// </summary>
+        /// <param name="maxInactive">The maximum amount of inactive items to keep</param>
+        public void Shrink(int maxInactive)
+        {
+            for (var i = _inactiveItems.Count - 1; i >= maxInactive && i >= 0; --i)
+                _inactiveItems.Pop();
+        }
+
 
         protected TContract GetInternal()
         {


### PR DESCRIPTION
Added method to shrink a MemoryPool down to a maximum of n inactiveItems. This can be important to reduce the size of a MemoryPool after a spike in usage which is higher than the expected count of objects.