### PR TITLE
fix runtime error for UWP

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Internal/TypeExtensions.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Internal/TypeExtensions.cs
@@ -385,7 +385,7 @@ namespace ModestTree
         {
             Attribute[] allAttributes;
 #if NETFX_CORE 
-            allAttributes = provider.GetType().GetTypeInfo().GetCustomAttributes<Attribute>().ToArray(); 
+            allAttributes = provider.GetCustomAttributes<Attribute>(true).ToArray(); 
 #else  
             allAttributes = System.Attribute.GetCustomAttributes(provider, typeof(Attribute), true);
 #endif
@@ -423,7 +423,7 @@ namespace ModestTree
         {
             Attribute[] allAttributes;
 #if NETFX_CORE 
-            allAttributes = provider.GetType().GetTypeInfo().GetCustomAttributes<Attribute>().ToArray(); 
+            allAttributes = provider.GetCustomAttributes<Attribute>(true).ToArray(); 
 #else  
             allAttributes = System.Attribute.GetCustomAttributes(provider, typeof(Attribute), true);
 #endif


### PR DESCRIPTION
fix for #440.
I was a little quick on #442, it fixed the compile error, but broke all injection (on UWP) at runtime. Sorry.