### PR TITLE
Allow firing undeclared signals

### DIFF
--- a/Documentation/Signals.md
+++ b/Documentation/Signals.md
@@ -318,6 +318,33 @@ public class UserManager
 }
 ```
 
+When `Fire()` is called, SignalBus expects the signal to be declared and exception will be thrown if the signal is not declared. If you want to call `Fire()` regardless of the signal declaration, use `TryFire()` method instead that ignores undeclared signals. You can use `TryFire()` looks like this:
+
+```csharp
+public class UserJoinedSignal
+{
+}
+
+public class UserManager
+{
+    readonly SignalBus _signalBus;
+
+    public UserManager(SignalBus signalBus)
+    {
+        _signalBus = signalBus;
+    }
+
+    public void DoSomething()
+    {
+        // Generic version
+        _signalBus.TryFire<UserJoinedSignal>(); // Nothing happens if UserJoinedSignal is NOT declared
+
+        // Non-Generic version
+        _signalBus.TryFire(new UserJoinedSignal()); // Nothing happens if UserJoinedSignal is NOT declared
+    }
+}
+```
+
 ## <a id="#bindsignal"></a>Binding Signals with BindSignal
 
 As mentioned above, in addition to being able to directly subscribe to signals on the signal bus (via `SignalBus.Subscribe` or `SignalBus.GetStream`) you can also directly bind a signal to a handling class inside an installer.  This approach has advantages and disadvantages compared to directly subscribing in a handling class so again comes down to personal preference.

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
@@ -80,6 +80,25 @@ namespace Zenject
             GetDeclaration(signal.GetType()).Fire(signal);
         }
 
+        public void TryFire<TSignal>()
+        {
+            var declaration = GetDeclaration(typeof(TSignal), false);
+            if (declaration != null)
+            {
+                declaration.Fire(
+                    (TSignal)Activator.CreateInstance(typeof(TSignal)));
+            }
+        }
+
+        public void TryFire(object signal)
+        {
+            var declaration = GetDeclaration(signal.GetType(), false);
+            if (declaration != null)
+            {
+                declaration.Fire(signal);
+            }
+        }
+
 #if ZEN_SIGNALS_ADD_UNIRX
         public IObservable<TSignal> GetStream<TSignal>()
         {
@@ -191,7 +210,7 @@ namespace Zenject
             _subscriptionMap.Add(id, subscription);
         }
 
-        SignalDeclaration GetDeclaration(Type signalType)
+        SignalDeclaration GetDeclaration(Type signalType, bool requireDeclaration = true)
         {
             SignalDeclaration handler;
 
@@ -202,11 +221,18 @@ namespace Zenject
 
             if (_parentBus != null)
             {
-                return _parentBus.GetDeclaration(signalType);
+                return _parentBus.GetDeclaration(signalType, requireDeclaration);
             }
 
-            throw Assert.CreateException(
-                "Fired undeclared signal with type '{0}'!", signalType);
+            if (requireDeclaration)
+            {
+                throw Assert.CreateException(
+                    "Fired undeclared signal with type '{0}'!", signalType);
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Because I love the brand new Signal system, may I request this?

To make more "fire and forget" Signal system, calling `Fire()` regardless whether the signal is declared is better I thought. Imagine this situation:

You have VideoPlayer class that fires VideoPlayer.OnPauseSignal (nested in VideoPlayer class). VideoPlayer is used in both SceneA and SceneB. In SceneA, OnPauseSignal is used to invoke some action but not in SceneB. In this case, you want to declare OnPauseSignal only in the SceneContext of SceneA, don't you?

With C# delegate(or event), you can check if the delegate is null or not. With UnityAction, nothing happens if the action have no listeners. So we need some workaround for Signals.