### PR TITLE
Fixes for "InvalidCastException: Specified cast is not valid." exception when validating decorator.

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Providers/Decorator/DecoratorProvider.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Providers/Decorator/DecoratorProvider.cs
@@ -68,6 +68,20 @@ namespace Zenject.Internal
             var rawInstances = provider.GetAllInstances(context);
             var decoratedInstances = new List<object>(rawInstances.Count);
 
+            if (context.Container.IsValidating)
+            {
+                for (int i = 0; i < rawInstances.Count; i++)
+                {
+                    for (int j = 0; j < _decoratorFactories.Count; j++)
+                    {
+                        decoratedInstances.Add(
+                            _decoratorFactories[j].Create(default(TContract)));
+                    }
+                }
+
+                return decoratedInstances;
+            }
+
             for (int i = 0; i < rawInstances.Count; i++)
             {
                 decoratedInstances.Add(DecorateInstance(


### PR DESCRIPTION
When I validated contexts that use Decorator, I got a exception below everytime. This PR will fix this issue. I used Zenject for a week or such, so not sure about this is a right fix.

<img width="309" alt="screen shot 2018-08-08 at 11 19 38 pm" src="https://user-images.githubusercontent.com/2816012/43843079-b28c4328-9b61-11e8-848e-25cc3b67181b.png">

Here's a detail of exception.
```
InvalidCastException: Specified cast is not valid.
(wrapper castclass) System.Object.__castclass_with_cache(object,intptr,intptr)
Zenject.Internal.DecoratorProvider`1[TContract].WrapProviderInstances (Zenject.IProvider provider, Zenject.InjectContext context) (at Assets/Plugins/Zenject/Source/Providers/Decorator/DecoratorProvider.cs:87)
Zenject.Internal.DecoratorProvider`1[TContract].GetAllInstances (Zenject.IProvider provider, Zenject.InjectContext context) (at Assets/Plugins/Zenject/Source/Providers/Decorator/DecoratorProvider.cs:52)
Zenject.DiContainer.GetDecoratedInstances (Zenject.IProvider provider, Zenject.InjectContext context) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1137)
Zenject.DiContainer.SafeGetInstances (Zenject.DiContainer+ProviderInfo providerInfo, Zenject.InjectContext context) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1079)
Zenject.DiContainer.Resolve (Zenject.InjectContext context) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1004)
Zenject.DiContainer.InjectExplicitInternal (System.Object injectable, System.Type injectableType, Zenject.InjectArgs args) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1409)
Zenject.DiContainer.InjectExplicit (System.Object injectable, System.Type injectableType, Zenject.InjectArgs args) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1347)
UnityEngine.Debug:LogException(Exception)
ModestTree.Log:ErrorException(Exception) (at Assets/Plugins/Zenject/Source/Internal/Log.cs:60)
Zenject.DiContainer:InjectExplicit(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1351)
Zenject.<>c__DisplayClass10_0:<GetAllInstancesWithInjectSplit>b__0() (at Assets/Plugins/Zenject/Source/Providers/TransientProvider.cs:68)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext, List`1) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:34)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:19)
Zenject.Internal.DecoratorProvider`1:WrapProviderInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/Decorator/DecoratorProvider.cs:68)
Zenject.Internal.DecoratorProvider`1:GetAllInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/Decorator/DecoratorProvider.cs:52)
Zenject.DiContainer:GetDecoratedInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1137)
Zenject.DiContainer:SafeGetInstances(ProviderInfo, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1079)
Zenject.DiContainer:Resolve(InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1004)
Zenject.DiContainer:InjectExplicitInternal(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1409)
Zenject.DiContainer:InjectExplicit(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1347)
Zenject.DiContainer:InjectExplicit(Object, List`1) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1313)
Zenject.DiContainer:Inject(Object, IEnumerable`1) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:2232)
Zenject.DiContainer:Inject(Object) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:2224)
Zenject.LazyInstanceInjector:LazyInject(Object) (at Assets/Plugins/Zenject/Source/Main/LazyInstanceInjector.cs:47)
Zenject.DiContainer:LazyInject(Object) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:449)
Zenject.InstanceProvider:<GetAllInstancesWithInjectSplit>b__9_0() (at Assets/Plugins/Zenject/Source/Providers/InstanceProvider.cs:44)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext, List`1) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:34)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:19)
Zenject.DiContainer:GetDecoratedInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1140)
Zenject.DiContainer:SafeGetInstances(ProviderInfo, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1079)
Zenject.DiContainer:Resolve(InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1004)
Zenject.DiContainer:InjectExplicitInternal(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1409)
Zenject.DiContainer:InjectExplicit(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1347)
Zenject.<>c__DisplayClass10_0:<GetAllInstancesWithInjectSplit>b__0() (at Assets/Plugins/Zenject/Source/Providers/TransientProvider.cs:68)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext, List`1) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:34)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:19)
Zenject.DiContainer:GetDecoratedInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1140)
Zenject.DiContainer:SafeGetInstances(ProviderInfo, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1079)
Zenject.DiContainer:Resolve(InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1004)
Zenject.DiContainer:InjectExplicitInternal(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1409)
Zenject.DiContainer:InjectExplicit(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1347)
Zenject.<>c__DisplayClass10_0:<GetAllInstancesWithInjectSplit>b__0() (at Assets/Plugins/Zenject/Source/Providers/TransientProvider.cs:68)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext, List`1) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:34)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:19)
Zenject.DiContainer:GetDecoratedInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1140)
Zenject.DiContainer:SafeGetInstances(ProviderInfo, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1079)
Zenject.DiContainer:ResolveAllInternal(InjectContext, List`1) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:748)
Zenject.DiContainer:ResolveAll(InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:713)
Zenject.DiContainer:Resolve(InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:989)
Zenject.DiContainer:InjectExplicitInternal(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1409)
Zenject.DiContainer:InjectExplicit(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1347)
Zenject.<>c__DisplayClass10_0:<GetAllInstancesWithInjectSplit>b__0() (at Assets/Plugins/Zenject/Source/Providers/TransientProvider.cs:68)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext, List`1) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:34)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:19)
Zenject.DiContainer:GetDecoratedInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1140)
Zenject.DiContainer:SafeGetInstances(ProviderInfo, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1079)
Zenject.DiContainer:Resolve(InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1004)
Zenject.DiContainer:InjectExplicitInternal(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1409)
Zenject.DiContainer:InjectExplicit(Object, Type, InjectArgs) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1347)
Zenject.<>c__DisplayClass16_0:<GetAllInstancesWithInjectSplit>b__0() (at Assets/Plugins/Zenject/Source/Providers/ComponentProviders/AddToGameObjectComponentProviders/AddToGameObjectComponentProviderBase.cs:112)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext, List`1) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:34)
Zenject.IProviderExtensions:GetAllInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Providers/IProviderExtensions.cs:19)
Zenject.DiContainer:GetDecoratedInstances(IProvider, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1140)
Zenject.DiContainer:SafeGetInstances(ProviderInfo, InjectContext) (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:1079)
Zenject.DiContainer:ResolveDependencyRoots() (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:370)
Zenject.DiContainer:ResolveRoots() (at Assets/Plugins/Zenject/Source/Main/DiContainer.cs:312)
Zenject.SceneContext:Resolve() (at Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs:284)
Zenject.SceneContext:Validate() (at Assets/Plugins/Zenject/Source/Install/Contexts/SceneContext.cs:115)
Zenject.Internal.ZenUnityEditorUtil:ValidateCurrentSceneSetup() (at Assets/Plugins/Zenject/Source/Editor/ZenUnityEditorUtil.cs:69)
Zenject.Internal.<>c:<ValidateCurrentSceneInternal>b__17_0() (at Assets/Plugins/Zenject/Source/Editor/ZenMenuItems.cs:281)
Zenject.Internal.ZenUnityEditorUtil:SaveThenRunPreserveSceneSetup(Action) (at Assets/Plugins/Zenject/Source/Editor/ZenUnityEditorUtil.cs:26)
Zenject.Internal.ZenMenuItems:ValidateCurrentSceneInternal() (at Assets/Plugins/Zenject/Source/Editor/ZenMenuItems.cs:278)
Zenject.Internal.ZenMenuItems:ValidateCurrentSceneThenRun() (at Assets/Plugins/Zenject/Source/Editor/ZenMenuItems.cs:27)
```