### PR TITLE
feat(SignalBus): Add ParentBus property

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
@@ -36,6 +36,11 @@ namespace Zenject
             _parentBus = parentBus;
         }
 
+        public SignalBus ParentBus
+        {
+            get { return _parentBus; }
+        }
+
         public int NumSubscribers
         {
             get { return _subscriptionMap.Count; }


### PR DESCRIPTION
Hi.

I've added ParentBus property in SignalBus

#### Why?
I have multiple components which implement a custom interface IManagedElement.
Their parent implements (custom) IElementManager.
IElementManager is also IManagedElement, which means it will be managed by another IElementManager (up the chain) too.

Each IElementManager component also has a (GameObject / Scene)Context, with installers which redeclare the signals used by IElementManager and IManagedElement implementations.

Every IElementManager subscribes to these signals and also notifies parent IElementManager instances.

It basically enables me to control their lifecycles (correct animation sequences, states, ..) without tight coupling.

#### Here's the example scene
```
- SceneContext(Game : IElementManager)
+ GameObjectContext(GameHUD : IElementManager)
  + Shield : IManagedElement
  + Health : IManagedElement
  + Stamina : IManagedElement
  + Ammo : IManagedElement
+ GameObjectContext(UnitStats : IElementManager)
  + Shield : IManagedElement
  + Health : IManagedElement
+ GameObjectContext(Unit : IElementManager)
  + Sight : IManagedElement
  + Body : IManagedElement
```

Innermost (leafs) components fire an event when they're ready, which is captured by their parent node - that parent then fires an event (on parent's context) when ready, etc.