### PR TITLE
Fixed ByNewPrefabResourceInstaller description of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ Where:
         ```csharp
         Container.Bind<Foo>().FromSubContainerResolve().ByNewPrefabResourceInstaller<FooInstaller>("Path/To/MyPrefab");
 
-        class FooInstaller : MonoInstaller
+        class FooInstaller : Installer<FooInstaller>
         {
             public override void InstallBindings()
             {


### PR DESCRIPTION
Hi.
The explanation about `ByNewPrefabResourceInstaller` seemed not to be appropriate, so I fixed it.
Because `ByNewPrefabResourceInstaller` has to inherit `InstallerBase`, it should be a class that inherited `Installer`, not `MonoInstaller`.

refs test code
https://github.com/modesttree/Zenject/blob/8ad1c8c11eb328ab625438d4cc05c505e6be9fdd/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Bindings/TestFromPrefabInstaller/TestFromPrefabInstaller.cs#L50-L61

https://github.com/modesttree/Zenject/blob/8ad1c8c11eb328ab625438d4cc05c505e6be9fdd/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Bindings/TestFromPrefabInstaller/TestFromPrefabInstaller.cs#L91-L97

Sorry if it is not wrong.