### PR TITLE
Update SignalBus.cs to fix compiler error

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
@@ -157,7 +157,7 @@ namespace Zenject
 #if ZEN_SIGNALS_ADD_UNIRX
         public IObservable<TSignal> GetStreamId<TSignal>(object identifier)
         {
-            return GetStream(typeof(TSignal), identifier).Select(x => (TSignal)x);
+            return GetStreamId(typeof(TSignal), identifier).Select(x => (TSignal)x);
         }
 
         public IObservable<TSignal> GetStream<TSignal>()


### PR DESCRIPTION
ZEN_SIGNALS_ADD_UNIRX currently does not compile because "GetStream<TSignal>(object identifier)" calls a function with an old signature.