### PR TITLE
replaces overloads with optionals in SceneLoader.LoadScene.

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenjectSceneLoader.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Util/ZenjectSceneLoader.cs
@@ -34,37 +34,12 @@ namespace Zenject
             _sceneContainer = sceneRoot == null ? null : sceneRoot.Container;
         }
 
-        public void LoadScene(string sceneName)
-        {
-            LoadScene(sceneName, LoadSceneMode.Single);
-        }
-
-        public void LoadScene(string sceneName, LoadSceneMode loadMode)
-        {
-            LoadScene(sceneName, loadMode, null);
-        }
-
-        public void LoadScene(
-            string sceneName, LoadSceneMode loadMode, Action<DiContainer> extraBindings)
-        {
-            LoadScene(sceneName, loadMode, extraBindings, LoadSceneRelationship.None);
-        }
-
         public void LoadScene(
             string sceneName,
-            LoadSceneMode loadMode,
-            Action<DiContainer> extraBindings,
-            LoadSceneRelationship containerMode)
-        {
-            LoadScene(sceneName, loadMode, extraBindings, containerMode, null);
-        }
-
-        public void LoadScene(
-            string sceneName,
-            LoadSceneMode loadMode,
-            Action<DiContainer> extraBindings,
-            LoadSceneRelationship containerMode,
-            Action<DiContainer> extraBindingsLate)
+            LoadSceneMode loadMode = LoadSceneMode.Single,
+            Action<DiContainer> extraBindings = null,
+            LoadSceneRelationship containerMode = LoadSceneRelationship.None,
+            Action<DiContainer> extraBindingsLate = null)
         {
             PrepareForLoadScene(loadMode, extraBindings, extraBindingsLate, containerMode);
 


### PR DESCRIPTION
This allows defaults and explicit values to be used in any combination,
and makes those defaults clear.

Functionality is identical. All Unity Editor-Nunit Tests passed.