### PR TITLE
Allow to use scenes without having them registered at build settings

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/EditorSceneTestFixture.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/EditorSceneTestFixture.cs
@@ -1,0 +1,86 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using ModestTree;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Zenject;
+using Zenject.Internal;
+using Assert = ModestTree.Assert;
+
+namespace Zenject {
+    public abstract class EditorSceneTestFixture {
+        private readonly List<DiContainer> _sceneContainers = new List<DiContainer>();
+
+        private bool _hasLoadedScene;
+
+        protected DiContainer SceneContainer { get; private set; }
+        protected IEnumerable<DiContainer> SceneContainers => _sceneContainers;
+
+        public IEnumerator LoadScene(string scenePath) {
+            return LoadScenes(scenePath);
+        }
+
+        public IEnumerator LoadScenes(params string[] scenePaths) {
+            Assert.That(!_hasLoadedScene, "Attempted to load scene twice!");
+            _hasLoadedScene = true;
+
+            // Clean up any leftovers from previous test
+            ZenjectTestUtil.DestroyEverythingExceptTestRunner(false);
+
+            Assert.That(SceneContainers.IsEmpty());
+
+            for (var i = 0; i < scenePaths.Length; i++) {
+                var scenePath = scenePaths[i];
+
+                Log.Info("Loading scene '{0}' for testing", scenePath);
+
+                var loader =
+                    EditorSceneManager.LoadSceneAsyncInPlayMode(scenePath, new LoadSceneParameters(
+                        i == 0 ? LoadSceneMode.Single : LoadSceneMode.Additive
+                    ));
+
+                while (!loader.isDone) {
+                    yield return null;
+                }
+
+                SceneContext sceneContext = null;
+
+                // ProjectContext might be null if scene does not have a scene context
+                if (ProjectContext.HasInstance) {
+                    var scene = SceneManager.GetSceneByPath(scenePath);
+
+                    sceneContext = ProjectContext.Instance.Container.Resolve<SceneContextRegistry>()
+                        .TryGetSceneContextForScene(scene);
+                }
+
+                _sceneContainers.Add(sceneContext == null ? null : sceneContext.Container);
+            }
+
+            SceneContainer = _sceneContainers.LastOrDefault(x => x != null);
+
+            SceneContainer?.Inject(this);
+        }
+
+        [SetUp]
+        public virtual void SetUp() {
+            StaticContext.Clear();
+            SetMemberDefaults();
+        }
+
+        private void SetMemberDefaults() {
+            _hasLoadedScene = false;
+            SceneContainer = null;
+            _sceneContainers.Clear();
+        }
+
+        [TearDown]
+        public virtual void Teardown() {
+            ZenjectTestUtil.DestroyEverythingExceptTestRunner(true);
+            StaticContext.Clear();
+            SetMemberDefaults();
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/EditorSceneTestFixture.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/EditorSceneTestFixture.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 528345f4481a4262b55340fa876eabbf
+timeCreated: 1577785114


### PR DESCRIPTION
Hi,

I don't like that I can only test scenes which were added to the build settings. So I took the SceneTestFixture as a base and created the class you can see inside of the PR. 

With this class you can test any scene by just providing the path(s).