### PR TITLE
Fix running play-mode tests in player

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/Zenject-TestFramework.asmdef
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/Zenject-TestFramework.asmdef
@@ -6,9 +6,10 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
 }


### PR DESCRIPTION
I was not able to run play-mode tests using the Zenject.SceneTestFixture in a player (instead of in the Editor) until I removed the restriction to the Editor platform for the Zenject-TestFramework asmdef. It makes kind of sense, as it will be running on other platforms, not in the Editor.

I guess the reason for having it there is to prevent Unity from including the test framework in the actual builds. I think this can be achieved as well by adding the "UNITY_INCLUDE_TESTS" constraint. Could you double-check if that works for you?